### PR TITLE
[Doc] ADR-01 — core architecture and community decisions

### DIFF
--- a/docs/adr/ADR-01_core.md
+++ b/docs/adr/ADR-01_core.md
@@ -206,7 +206,8 @@ These are explicitly left open for discussion.
 
 **From PR review discussion:**
 
-8. **Batch API.** How should the gateway handle batch API requests if vLLM lacks a corresponding endpoint?
-9. **Skills / agent capabilities.** Should the gateway expose a skills endpoint for agent capabilities that don't require LLM inference? Could follow a "local shell mode" pattern.
+8. **Batch API.** How should the gateway handle batch API requests given that vLLM does not provide a native batch endpoint? The proposed approach is to implement batch functionality within this repository by dispatching multiple individual requests (e.g., `/v1/chat/completions`, `/v1/responses`, or embedding/rerank endpoints) to the vLLM server.
+9. **Skills / agent capabilities.** Should the gateway expose a skills endpoint for agent capabilities that don't require LLM inference? Could follow a "local shell mode" pattern similar to OpenAI local shell mode https://developers.openai.com/api/docs/guides/tools-skills#use-skills-with-local-shell-mode .
 10. **CLI integration surface.** Should the Entry Points layer own a CLI integration like `vllm serve --agentic-stack <model>`?
 11. **Connectors API pattern.** Should the internal vLLM protocol (if pursued) follow OpenAI's Connectors API pattern, or is MCP sufficient as the standard?
+- Proposed approach is to set MCP as the primary interface following the OpenAI standard of handling remote MCP and connectors https://developers.openai.com/api/docs/guides/tools-connectors-mcp . Connectors are just OpenAI-maintained MCP wrappers (as written in their docs).


### PR DESCRIPTION
## Summary

Wrote up ADR-01 to capture where we landed (and where we didn't) from the kickoff meeting and the Slack threads that followed. Covers:

- Upstream interface decision (stateless Responses API, not Chat Completions or llm.generate)
- Tokenization stays in vLLM core (per Ben's strong recommendation + llm-d lessons learned)
- Language vote (Python)
- GPT-OSS / Harmony considerations and the open question around Harmony-specific fields
- Six-layer package structure proposal with MVP scoped to layers 1-3 + 6
- Early direction on the response store (single-table, flattened history, SQLite default) — will be its own ADR once this one settle

Tried to attribute positions where I could so people could correct me if I got their take wrong. There are 7 open questions at the bottom that I think we need community input on before moving forward — especially around Tun Jian's internal protocol proposal and how Harmony fields should flow through.

This is a Draft. Please poke holes.

## Test Plan

<!-- Describe how the changes were tested. -->
