### PR TITLE
docs: add ADR-03 gateway-agnostic layered architecture

### DIFF
--- a/docs/adr/ADR-03_gateway_integration.md
+++ b/docs/adr/ADR-03_gateway_integration.md
@@ -129,7 +129,7 @@ pub async fn assemble_response(...) -> Result<Response, Error>
 pub async fn persist_response(...) -> Result<(), Error>
 ```
 
-`execute()` is a convenience that composes these steps with the default loop logic. Consumers who need fine-grained control (custom middleware between steps, per-step observability, conditional branching) call the individual functions directly.
+`execute()` is a convenience that composes these steps with the default loop logic. Consumers who need fine-grained control (custom middleware between steps, per-step observability, conditional branching) call the individual functions directly. Each function can also be wrapped in its own gateway filter — a consumer who wants per-step filters can build them from these primitives without the core prescribing the decomposition.
 
 Dependencies: `tokio`, `reqwest`, `serde`, `serde_json`, `sqlx`, `thiserror`. No server-side framework dependencies (`axum`, `praxis`, `tower`).
 

--- a/docs/adr/ADR-03_gateway_integration.md
+++ b/docs/adr/ADR-03_gateway_integration.md
@@ -383,3 +383,5 @@ PR #27 decomposes the agentic loop into multiple Praxis filters (`responses_prox
 3. **Guardrails integration point.** Input guardrails can run in Praxis (pre-routing) or in agentic-api (post-hydration, with full conversation context). Output guardrails must run in agentic-api (per loop iteration). The split needs to be validated with the guardrails team.
 
 4. **In-process vs service mode trade-offs.** Mode 2 (service) adds ~1ms per loop iteration but gives process isolation and independent scaling. Mode 3 (in-process) eliminates the hop but shares failure domains. Which is the default recommendation for production?
+
+5. **Separate tools crate.** Tools currently live in `agentic-core`. If a tool implementation requires non-Rust-native dependencies (C bindings, external libraries), it may make sense to split tools into a separate `agentic-tools` crate to avoid polluting `agentic-core`'s dependency tree. Revisit when tool implementations land.

--- a/docs/adr/ADR-03_gateway_integration.md
+++ b/docs/adr/ADR-03_gateway_integration.md
@@ -19,7 +19,7 @@ This ADR settles:
 
 Agentic-api is the orchestration core for the vLLM Responses API. It manages the agentic loop: conversation rehydration, inference calling, tool dispatch, response persistence. The question is how it relates to the gateway proxy that sits in front of it.
 
-Note: ADR-01 decided on Python as the project language. The project has since transitioned to Rust ([PR #23](https://github.com/vllm-project/agentic-api/pull/23)), and once accepted, this ADR will supersede ADR-01's language decision (D3).
+Note: ADR-01 decided on Python as the project language. PR #23 transitioned the project to Rust, superseding ADR-01's language decision (D3). This ADR assumes Rust throughout.
 
 ### Praxis as the gateway
 
@@ -281,7 +281,7 @@ request arrives
   → response to client
 ```
 
-Each filter is a thin wrapper (~10 lines). All domain logic lives in `agentic-core`. Consumers customize the loop by editing the YAML — inserting filters (e.g. guardrails between inference and tool dispatch), reordering steps, or replacing filters with custom implementations. This uses Praxis's filter chain and branch constructs natively ([praxis#354](https://github.com/praxis-proxy/praxis/issues/354)).
+Each filter is a thin wrapper (~10 lines). All domain logic lives in `agentic-core`. Consumers customize the loop by editing YAML to add/remove/reorder/reconfigure filters that are already registered in the Praxis binary (for example, inserting a guardrail filter between inference and tool dispatch). Adding a brand-new custom filter implementation requires registering it in code and rebuilding the Praxis binary. This uses Praxis's filter chain and branch constructs natively ([praxis#354](https://github.com/praxis-proxy/praxis/issues/354)).
 
 #### In standalone mode
 
@@ -313,7 +313,7 @@ Both use the same `agentic-core` public functions — the domain logic is always
 
 - **Testability.** Core logic is tested without any HTTP server or gateway infrastructure.
 - **Composability.** Consumers can customize the agentic loop by wiring individual functions differently — adding steps, reordering, or replacing functions.
-- **Independent scaling.** As a service, agentic-api scales separately from the gateway. As an in-process filter, it shares the gateway's resources — the deployment choice is made at deploy time, not compile time.
+- **Independent scaling.** As a service, agentic-api scales separately from the gateway. As an in-process filter, it shares the gateway's resources. Runtime topology is a deployment decision, but in-process mode requires a Praxis build that includes `agentic-praxis` and its filter registrations.
 - **Release independence.** Core and server ship on their own schedule. Adapters depend on the core crate version, not on the gateway's release cycle.
 
 ---

--- a/docs/adr/ADR-03_gateway_integration.md
+++ b/docs/adr/ADR-03_gateway_integration.md
@@ -19,6 +19,8 @@ This ADR settles:
 
 Agentic-api is the orchestration core for the vLLM Responses API. It manages the agentic loop: conversation rehydration, inference calling, tool dispatch, response persistence. The question is how it relates to the gateway proxy that sits in front of it.
 
+Note: ADR-01 decided on Python as the project language. The project has since transitioned to Rust ([PR #23](https://github.com/vllm-project/agentic-api/pull/23)), and once accepted, this ADR will supersede ADR-01's language decision (D3).
+
 ### The gateway landscape
 
 Multiple gateway options exist: Praxis (Rust, early-stage, co-development opportunity), Kong, Envoy, or no gateway at all (standalone mode for development). Coupling the orchestration core to any single gateway's plugin API creates lock-in and limits adoption.
@@ -37,15 +39,15 @@ One integration model has been proposed: decompose the agentic loop into **Praxi
 ┌─────────────────────────────────────────────┐
 │  Layer 3: Thin adapters (one per gateway)   │
 │                                             │
-│  ┌───────────┐ ┌───────┐ ┌──────┐ ┌─────┐   │
-│  │   axum    │ │Praxis │ │ Kong │ │ ... │   │
-│  │(standalone)│ filter │ │plugin│ │     │   │
-│  └───────────┘ └───────┘ └──────┘ └─────┘   │
+│  ┌───────┐ ┌──────┐ ┌─────┐                 │
+│  │Praxis │ │ Kong │ │ ... │                 │
+│  │ filter│ │plugin│ │     │                 │
+│  └───────┘ └──────┘ └─────┘                 │
 ├─────────────────────────────────────────────┤
-│  Layer 2: HTTP API (service mode)           │
+│  Layer 2: HTTP API (agentic-server / axum)  │
 │                                             │
 │  POST /v1/responses → calls into core       │
-│  SSE streaming, health checks               │
+│  SSE streaming, health checks, CLI          │
 ├─────────────────────────────────────────────┤
 │  Layer 1: Core library                      │
 │  (pure Rust, no framework dependency)       │
@@ -119,11 +121,11 @@ pub async fn execute(
 ) -> Result<ResponseStream, Error>
 ```
 
-Dependencies: `tokio`, `reqwest`, `serde`, `serde_json`, `sqlx`, `thiserror`. No `axum`, no `praxis`, no `tower`, no `hyper`.
+Dependencies: `tokio`, `reqwest`, `serde`, `serde_json`, `sqlx`, `thiserror`. No server-side framework dependencies (`axum`, `praxis`, `tower`).
 
 ### Layer 2: `agentic-server`
 
-Thin axum wrapper. Parses HTTP, calls `agentic_core::execute()`, streams the result. Owns the CLI (`clap`), vLLM subprocess management, and standalone server lifecycle. This is what PR #24 builds today.
+Thin axum wrapper. Parses HTTP, calls `agentic_core::execute()`, streams the result. Owns the CLI (`clap`), vLLM subprocess management, and standalone server lifecycle. PR #24 will introduce the proxy logic, configuration, error handling, and CLI that form the basis of this layer.
 
 ### Layer 3: `agentic-praxis`
 
@@ -257,15 +259,15 @@ MODE 3: Production (in-process)
 
 ### PR #24 — Rust proxy gateway
 
-PR #24 becomes the foundation of `agentic-core` and `agentic-server`. The proxy logic (`proxy.rs`), configuration (`config.rs`), error handling (`error.rs`), and CLI (`main.rs`) evolve into the layered crate structure. The standalone `serve` mode remains first-class in `agentic-server`. Benchmarks stay.
+PR #24 will become the foundation of `agentic-core` and `agentic-server`. The proxy logic, configuration, error handling, and CLI it introduces will evolve into the layered crate structure. The standalone `serve` mode remains first-class in `agentic-server`. Benchmarks stay.
 
 The workspace migration (flat crate → workspace with `crates/`) is a follow-up after PR #24 merges. PR #24 ships as-is — it's correct and complete for the current scope.
 
 ### PR #27 — Praxis filter-based architecture
 
-PR #27 decomposes the agentic loop into multiple Praxis filters (`responses_proxy`, `agentic_loop`, `state_hydration`, `tool_dispatch`). This ADR supersedes that approach: the loop stays as an explicit state machine in `agentic-core`, and the Praxis integration is a single thin filter in `agentic-praxis`.
+PR #27 decomposes the agentic loop into multiple Praxis filters (`responses_proxy`, `agentic_loop`, `state_hydration`, `tool_dispatch`). If accepted, this ADR supersedes that approach: the loop stays as an explicit state machine in `agentic-core`, and the Praxis integration is a single thin filter in `agentic-praxis`.
 
-PR #27 should be closed in favor of this architecture.
+If accepted, PR #27 should be closed in favor of this architecture.
 
 ---
 

--- a/docs/adr/ADR-03_gateway_integration.md
+++ b/docs/adr/ADR-03_gateway_integration.md
@@ -206,21 +206,82 @@ Praxis is what we start with. Because `agentic-core` functions are plain Rust wi
 
 #### In Praxis
 
-Each `agentic-core` function is wrapped in an `HttpFilter`. Praxis's filter chain orchestrates the loop — with branch chains handling tool-call re-entry:
+Each `agentic-core` function is wrapped in an `HttpFilter`. Praxis's filter chain orchestrates the loop — with branch chains handling tool-call re-entry.
+
+**Filter implementations** — thin wrappers that delegate to `agentic-core`:
+
+```rust
+struct InferenceFilter { vllm_url: String }
+impl HttpFilter for InferenceFilter {
+    async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction> {
+        let result = agentic_core::call_inference(ctx.get("conversation"), &self.vllm_url).await?;
+        ctx.set("inference_result", result);
+        Ok(FilterAction::Continue)
+    }
+}
+
+struct ToolDispatchFilter;
+impl HttpFilter for ToolDispatchFilter {
+    async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction> {
+        let result = ctx.get("inference_result");
+        if result.has_tool_calls() {
+            let tool_results = agentic_core::dispatch_tools(result.tool_calls()).await?;
+            ctx.set("conversation", result.with_tool_results(tool_results));
+            ctx.set_result("action", "loop");   // signal branch: tools called
+        } else {
+            ctx.set_result("action", "done");   // signal: no tools, continue
+        }
+        Ok(FilterAction::Continue)
+    }
+}
+```
+
+**YAML configuration** — Praxis orchestrates the loop declaratively:
+
+```yaml
+filter_chains:
+  - name: agentic-loop
+    filters:
+      - filter: rehydrate
+        name: rehydrate
+
+      - filter: inference
+        name: inference
+        vllm_base_url: "http://localhost:8000"
+
+      - filter: tool_dispatch
+        name: tool_dispatch
+        branch_chains:
+          - name: tool-call-loop
+            on_result:
+              filter: tool_dispatch
+              key: action
+              result: loop              # branch when tools were called
+            rejoin: inference           # re-enter at inference filter
+            max_iterations: 10          # cap tool-call iterations
+
+      - filter: assemble
+        name: assemble
+
+      - filter: persist
+        name: persist
+```
+
+**The resulting flow:**
 
 ```
-Client → Praxis filter chain
-           → auth / rate-limit / routing (gateway filters)
-           → rehydrate_conversation filter  (calls agentic_core::rehydrate_conversation)
-           → call_inference filter          (calls agentic_core::call_inference → vLLM)
-           → dispatch_tools filter          (calls agentic_core::dispatch_tools)
-           → [branch: re-enter if tool calls detected]
-           → assemble_response filter       (calls agentic_core::assemble_response)
-           → persist_response filter        (calls agentic_core::persist_response)
-           → response to client
+request arrives
+  → rehydrate         (agentic_core::rehydrate_conversation)
+  → inference          (agentic_core::call_inference → vLLM)
+  → tool_dispatch      (agentic_core::dispatch_tools)
+      ├─ action=loop → [branch: re-enter at inference, max 10 iterations]
+      └─ action=done → continue
+  → assemble           (agentic_core::assemble_response)
+  → persist            (agentic_core::persist_response)
+  → response to client
 ```
 
-Consumers customize the loop by reconfiguring the filter chain — inserting filters (e.g. guardrails between inference and tool dispatch), reordering steps, or replacing filters with custom implementations. This uses Praxis's filter chain and branch constructs natively ([praxis#354](https://github.com/praxis-proxy/praxis/issues/354)).
+Each filter is a thin wrapper (~10 lines). All domain logic lives in `agentic-core`. Consumers customize the loop by editing the YAML — inserting filters (e.g. guardrails between inference and tool dispatch), reordering steps, or replacing filters with custom implementations. This uses Praxis's filter chain and branch constructs natively ([praxis#354](https://github.com/praxis-proxy/praxis/issues/354)).
 
 #### In standalone mode
 

--- a/docs/adr/ADR-03_gateway_integration.md
+++ b/docs/adr/ADR-03_gateway_integration.md
@@ -112,14 +112,24 @@ agentic-api/
 
 ### Layer 1: `agentic-core`
 
-The core crate exports an async function that takes a request and returns a response stream. No HTTP types, no framework types — just domain types.
+The core crate exposes each step of the agentic loop as an individual public function. This allows consumers to compose steps with their own logic (e.g. rate limiting before tool invocation, custom guardrails between inference and response assembly).
 
 ```rust
+// High-level: run the full loop in one call
 pub async fn execute(
     request: ResponsesRequest,
-    ctx: &ExecutionContext,  // holds store, tools, inference client
+    ctx: &ExecutionContext,
 ) -> Result<ResponseStream, Error>
+
+// Individual loop steps — composable building blocks
+pub async fn rehydrate_conversation(...) -> Result<Conversation, Error>
+pub async fn call_inference(...) -> Result<InferenceResult, Error>
+pub async fn dispatch_tools(...) -> Result<Vec<ToolResult>, Error>
+pub async fn assemble_response(...) -> Result<Response, Error>
+pub async fn persist_response(...) -> Result<(), Error>
 ```
+
+`execute()` is a convenience that composes these steps with the default loop logic. Consumers who need fine-grained control (custom middleware between steps, per-step observability, conditional branching) call the individual functions directly.
 
 Dependencies: `tokio`, `reqwest`, `serde`, `serde_json`, `sqlx`, `thiserror`. No server-side framework dependencies (`axum`, `praxis`, `tower`).
 

--- a/docs/adr/ADR-03_gateway_integration.md
+++ b/docs/adr/ADR-03_gateway_integration.md
@@ -25,11 +25,11 @@ Note: ADR-01 decided on Python as the project language. The project has since tr
 
 Praxis is the primary gateway for agentic-api. It is a Rust-native, early-stage proxy with a co-development opportunity — agentic-api is an early adopter that validates Praxis's integration model with a real agentic workload.
 
-The out-of-the-box version of agentic-api ships a Praxis filter that composes the agentic loop by calling `agentic-core` public functions. The key requirement is that consumers can build their own filter with a different loop — adding, removing, or reordering steps — by calling the same public functions (requires recompilation, not dynamic).
+The out-of-the-box version of agentic-api ships a set of Praxis filters (each implementing `HttpFilter`) that compose the agentic loop, with each filter backed by an `agentic-core` public function. Praxis's filter chain with branch support orchestrates the loop — including branching back on tool calls. In standalone mode (no gateway), `execute()` composes the same functions with plain Rust control flow. The key requirement is that consumers can customize the loop — adding, removing, or reordering filters — by calling the same public functions (requires recompilation, not dynamic).
 
 ### The integration question
 
-One integration model has been proposed: decompose the agentic loop into **Praxis re-entrant filter chains** where each step is a Praxis-specific filter. An alternative is to implement the loop steps as plain Rust public functions that a Praxis filter calls to compose the loop. The functions are testable without Praxis and usable in standalone mode. Because they are plain Rust with no gateway-specific API, they could support other gateways in the future.
+The loop steps are implemented as plain Rust public functions in `agentic-core`. When integrated with Praxis, each function is wrapped in an `HttpFilter` and composed into a filter chain — using Praxis's branch chains to handle tool-call loops. In standalone mode, `execute()` composes the same functions with plain Rust control flow. Because the functions are plain Rust with no gateway-specific API, they could support other gateways in the future.
 
 ---
 
@@ -42,8 +42,9 @@ One integration model has been proposed: decompose the agentic loop into **Praxi
 │  Layer 3: Gateway adapter (Praxis)          │
 │                                             │
 │  ┌─────────────────────────┐                 │
-│  │  agentic-praxis filter  │                 │
-│  │  (composes the loop)    │                 │
+│  │  agentic-praxis         │                 │
+│  │  (HttpFilter impls      │                 │
+│  │   backed by core fns)   │                 │
 │  └─────────────────────────┘                 │
 ├─────────────────────────────────────────────┤
 │  Layer 2: HTTP API (agentic-server / axum)  │
@@ -72,9 +73,9 @@ One integration model has been proposed: decompose the agentic loop into **Praxi
 | # | Decision | Status |
 |---|----------|--------|
 | D1 | Core orchestration logic is a Rust library crate (`agentic-core`) that exposes each loop step as a public function — plain Rust, no gateway-specific API | Proposed |
-| D2 | The agentic loop is composed by calling `agentic-core` public functions — either inside a single filter (Model A) or across per-step filters with Praxis re-entrant chains (Model B); both use the same functions | Proposed |
+| D2 | The agentic loop is composed by calling `agentic-core` public functions — in Praxis, each function is an `HttpFilter` in a filter chain with branch support; in standalone mode, `execute()` composes them with plain Rust control flow | Proposed |
 | D3 | Response store, conversation manager, tool registry, and MCP client are implemented natively in Rust within `agentic-core` | Proposed |
-| D4 | Praxis integrates via `agentic-praxis`, a filter that composes the default loop by calling `agentic-core` public functions — deployed either as a backend service or as an in-process library | Proposed |
+| D4 | Praxis integrates via `agentic-praxis`, which wraps each `agentic-core` function in an `HttpFilter` — composed into a filter chain with branches for tool-call looping | Proposed |
 | D5 | Standalone mode (axum binary) is first-class — same core functions, different hosting | Proposed |
 
 ---
@@ -108,7 +109,7 @@ agentic-api/
     agentic-praxis/        # Layer 3: Praxis adapter
       Cargo.toml           # depends on agentic-core + praxis
       src/
-        lib.rs             # Single filter: receive request → core → stream response
+        lib.rs             # HttpFilter impls: each wraps an agentic-core function
 ```
 
 ### Layer 1: `agentic-core`
@@ -140,7 +141,7 @@ Thin axum wrapper. Parses HTTP, calls `agentic_core::execute()`, streams the res
 
 ### Layer 3: `agentic-praxis`
 
-The default Praxis filter. Composes the agentic loop internally by calling `agentic-core` public functions. The out-of-the-box filter calls `execute()` for the standard loop. Consumers who need a custom loop (e.g. adding rate limiting before tool invocation, or inserting guardrails between inference and assembly) build their own filter that calls the individual step functions directly.
+The Praxis integration crate. Each `agentic-core` public function is wrapped in an `HttpFilter` implementation. The out-of-the-box configuration assembles these filters into a filter chain with branch support for tool-call looping. Consumers who need a custom loop (e.g. adding rate limiting before tool invocation, or inserting guardrails between inference and assembly) reconfigure the filter chain — adding, removing, or reordering filters.
 
 Praxis depends on `agentic-praxis` as a crate, which transitively brings in `agentic-core`:
 
@@ -170,10 +171,10 @@ Client → Praxis (auth, rate-limit, routing) → agentic-server
 
 Praxis sees agentic-api as an HTTP backend — the same way it sees vLLM. For stateful requests (`previous_response_id`, tools), Praxis routes to agentic-api. For stateless pass-through, Praxis routes directly to vLLM.
 
-Alternatively, Praxis can link `agentic-praxis` as an in-process filter, eliminating the network hop while keeping the same core logic:
+Alternatively, Praxis can link `agentic-praxis` in-process, with each `agentic-core` function as an `HttpFilter` in the filter chain — eliminating the network hop while keeping the same core logic:
 
 ```
-Client → Praxis (auth, rate-limit, routing, agentic-praxis filter) → vLLM
+Client → Praxis (auth, rate-limit, routing, agentic-praxis filters) → vLLM
                                                 │
                                           agentic-core
                                           (in-process)
@@ -199,56 +200,53 @@ Praxis is what we start with. Because `agentic-core` functions are plain Rust wi
 
 ## Rationale
 
-### Two composition models from the same primitives
+### Same functions, different orchestrators
 
-Because `agentic-core` exposes each loop step as a public function, two composition models are possible — both use the same underlying code.
+`agentic-core` exposes each loop step as a public function. Who orchestrates the loop depends on the deployment context:
 
-#### Model A: Single filter (default)
+#### In Praxis
 
-One Praxis filter composes the full loop internally by calling `agentic-core` functions:
-
-```
-Client → Praxis filters (auth, rate-limit, routing)
-           → agentic-praxis filter
-               calls: rehydrate → inference → tool_dispatch → assemble → persist
-               (loop iteration is plain Rust control flow inside the filter)
-               (inference step calls vLLM internally; response returns to client)
-```
-
-This is what `agentic-praxis` ships out of the box. The loop is self-contained, testable with `cargo test`, and works in standalone mode (axum) without Praxis.
-
-#### Model B: Per-step filter chain ([praxis#354](https://github.com/praxis-proxy/praxis/issues/354))
-
-Each `agentic-core` function is wrapped in its own Praxis filter. Praxis's re-entrant filter chains orchestrate the loop iteration:
+Each `agentic-core` function is wrapped in an `HttpFilter`. Praxis's filter chain orchestrates the loop — with branch chains handling tool-call re-entry:
 
 ```
-Client → Praxis filters (auth, rate-limit, routing)
-           → conversation_retrieval filter  (calls rehydrate_conversation)
-           → pre_inference_guardrails filter
-           → inference filter               (calls call_inference)
-           → post_inference_guardrails filter
-           → tool_dispatch filter           (calls dispatch_tools)
-           → [re-enter chain if tool calls detected]
-           → response_assembly filter       (calls assemble_response)
-           → persistence filter             (calls persist_response)
+Client → Praxis filter chain
+           → auth / rate-limit / routing (gateway filters)
+           → rehydrate_conversation filter  (calls agentic_core::rehydrate_conversation)
+           → call_inference filter          (calls agentic_core::call_inference → vLLM)
+           → dispatch_tools filter          (calls agentic_core::dispatch_tools)
+           → [branch: re-enter if tool calls detected]
+           → assemble_response filter       (calls agentic_core::assemble_response)
+           → persist_response filter        (calls agentic_core::persist_response)
            → response to client
-           (inference filter calls vLLM internally)
 ```
 
-Each filter wraps an `agentic-core` public function — the domain logic stays in `agentic-core`, the orchestration moves to Praxis's filter pipeline.
+Consumers customize the loop by reconfiguring the filter chain — inserting filters (e.g. guardrails between inference and tool dispatch), reordering steps, or replacing filters with custom implementations. This uses Praxis's filter chain and branch constructs natively ([praxis#354](https://github.com/praxis-proxy/praxis/issues/354)).
+
+#### In standalone mode
+
+`execute()` composes the same functions with plain Rust control flow — no gateway, no pipeline framework:
+
+```
+Client → agentic-server (axum)
+           → agentic_core::execute()
+               rehydrate → inference (→ vLLM) → tool_dispatch → assemble → persist
+               (loop iteration is plain Rust async)
+           → response to client
+```
+
+This is the development and community-friendly mode. Anyone can use `agentic-core` as a library without Praxis or any specific gateway.
 
 #### Comparison
 
-| Concern | Model A (single filter) | Model B (per-step filters) |
-|---------|------------------------|---------------------------|
-| Loop control | Plain Rust control flow inside the filter | Praxis re-entrant filter chains |
-| Per-step customization | Call individual functions with custom logic between them | Insert custom filters between steps in the chain |
-| Observability | Explicit instrumentation inside the filter | Praxis provides per-filter metrics and tracing |
-| Standalone mode | Works as-is (axum) | Requires Praxis |
-| Praxis dependency | Runtime only (filter API) | Runtime + re-entrant chain support ([praxis#354](https://github.com/praxis-proxy/praxis/issues/354)) |
-| Testing | `cargo test` on `agentic-core` functions directly | `cargo test` on functions + Praxis filter harness for integration |
+| Concern | Praxis (filter chain) | Standalone (execute) |
+|---------|----------------------|----------------------|
+| Loop control | Filter chain with branch support for re-entry | Plain Rust control flow |
+| Customization | Reconfigure filter chain — add/remove/reorder filters | Call individual functions with custom logic between them |
+| Observability | Praxis provides per-filter metrics and tracing | Explicit instrumentation |
+| Gateway dependency | Praxis | None |
+| Testing | `cargo test` on functions + Praxis filter chain for integration | `cargo test` on functions directly |
 
-Both models use the same `agentic-core` public functions. Model A is the starting point; Model B becomes available as Praxis's re-entrant chain support matures. The migration path is: wrap each function call in its own filter and move loop control to Praxis — no changes to `agentic-core`.
+Both use the same `agentic-core` public functions — the domain logic is always in `agentic-core`, only the orchestrator differs.
 
 ### Why three layers
 
@@ -284,7 +282,7 @@ MODE 3: Production (in-process)
   Client
     │
     ▼
-  Praxis (with agentic-praxis filter linked)
+  Praxis (with agentic-praxis filters linked)
     │  gateway filters + agentic core in one process
     ▼
   vLLM / llm-d (fleet)
@@ -302,9 +300,7 @@ The workspace migration (flat crate → workspace with `crates/`) is a follow-up
 
 ### PR #27 — Praxis filter-based architecture
 
-PR #27 decomposes the agentic loop into multiple Praxis filters (`responses_proxy`, `agentic_loop`, `state_hydration`, `tool_dispatch`). If accepted, this ADR supersedes that approach: the loop stays as an explicit state machine in `agentic-core`, and the Praxis integration is a single thin filter in `agentic-praxis`.
-
-If accepted, PR #27 should be closed in favor of this architecture.
+PR #27 decomposes the agentic loop into multiple Praxis filters (`responses_proxy`, `agentic_loop`, `state_hydration`, `tool_dispatch`). This ADR aligns with that direction — each step is an `HttpFilter` in the filter chain — but with a key difference: the domain logic lives in `agentic-core` public functions, not in Praxis-specific filter implementations. PR #27's filter decomposition should be reworked so each filter delegates to an `agentic-core` function rather than implementing the logic directly.
 
 ---
 

--- a/docs/adr/ADR-03_gateway_integration.md
+++ b/docs/adr/ADR-03_gateway_integration.md
@@ -1,4 +1,4 @@
-# ADR-03 — Gateway-Agnostic Layered Architecture
+# ADR-03 — Layered Crate Architecture
 
 > **Status:** Draft
 > **Related:** [ADR-01 — Core Architecture](ADR-01_core.md), [ADR-02 — Response Store](ADR-02_response_store.md), [PR #24](https://github.com/vllm-project/agentic-api/pull/24), [PR #27](https://github.com/vllm-project/agentic-api/pull/27)
@@ -10,8 +10,8 @@
 This ADR settles:
 
 1. How agentic-api is structured as a crate workspace (three layers)
-2. How it integrates with gateway proxies (Praxis, and potentially others)
-3. Why the agentic loop is an explicit state machine, not proxy middleware
+2. How it integrates with Praxis as the primary gateway
+3. How the agentic loop is composed from public functions that can be customized
 
 ---
 
@@ -21,13 +21,15 @@ Agentic-api is the orchestration core for the vLLM Responses API. It manages the
 
 Note: ADR-01 decided on Python as the project language. The project has since transitioned to Rust ([PR #23](https://github.com/vllm-project/agentic-api/pull/23)), and once accepted, this ADR will supersede ADR-01's language decision (D3).
 
-### The gateway landscape
+### Praxis as the gateway
 
-Multiple gateway options exist: Praxis (Rust, early-stage, co-development opportunity), Kong, Envoy, or no gateway at all (standalone mode for development). Coupling the orchestration core to any single gateway's plugin API creates lock-in and limits adoption.
+Praxis is the primary gateway for agentic-api. It is a Rust-native, early-stage proxy with a co-development opportunity — agentic-api is an early adopter that validates Praxis's integration model with a real agentic workload.
+
+The out-of-the-box version of agentic-api ships a Praxis filter that composes the agentic loop by calling `agentic-core` public functions. The key requirement is that consumers can build their own filter with a different loop — adding, removing, or reordering steps — by calling the same public functions (requires recompilation, not dynamic).
 
 ### The integration question
 
-One integration model has been proposed: decompose the agentic loop into **Praxis re-entrant filter chains**. This spreads tightly coupled domain logic (conversation rehydration, tool dispatch, loop control, response assembly) across loosely coupled filters. These components share state, depend on execution order, and interact through response semantics — they are the core transaction, not cross-cutting concerns. Encoding them as filters makes the system harder to reason about, harder to test (requires full filter harness), and couples the release cycle to Praxis. Additionally, re-entrant filter chains don't exist in Praxis yet ([praxis#354](https://github.com/praxis-proxy/praxis/issues/354)).
+One integration model has been proposed: decompose the agentic loop into **Praxis re-entrant filter chains** where each step is a Praxis-specific filter. An alternative is to implement the loop steps as plain Rust public functions that a Praxis filter calls to compose the loop. The functions are testable without Praxis and usable in standalone mode. Because they are plain Rust with no gateway-specific API, they could support other gateways in the future.
 
 ---
 
@@ -37,12 +39,12 @@ One integration model has been proposed: decompose the agentic loop into **Praxi
 
 ```
 ┌─────────────────────────────────────────────┐
-│  Layer 3: Thin adapters (one per gateway)   │
+│  Layer 3: Gateway adapter (Praxis)          │
 │                                             │
-│  ┌───────┐ ┌──────┐ ┌─────┐                 │
-│  │Praxis │ │ Kong │ │ ... │                 │
-│  │ filter│ │plugin│ │     │                 │
-│  └───────┘ └──────┘ └─────┘                 │
+│  ┌─────────────────────────┐                 │
+│  │  agentic-praxis filter  │                 │
+│  │  (composes the loop)    │                 │
+│  └─────────────────────────┘                 │
 ├─────────────────────────────────────────────┤
 │  Layer 2: HTTP API (agentic-server / axum)  │
 │                                             │
@@ -69,12 +71,11 @@ One integration model has been proposed: decompose the agentic loop into **Praxi
 
 | # | Decision | Status |
 |---|----------|--------|
-| D1 | Core orchestration logic is a framework-agnostic Rust library crate (`agentic-core`) with no HTTP server or gateway dependencies | Proposed |
-| D2 | The agentic loop is an explicit async state machine in application code, not decomposed into proxy filter chains | Proposed |
+| D1 | Core orchestration logic is a Rust library crate (`agentic-core`) that exposes each loop step as a public function — plain Rust, no gateway-specific API | Proposed |
+| D2 | The agentic loop is composed by calling `agentic-core` public functions — either inside a single filter (Model A) or across per-step filters with Praxis re-entrant chains (Model B); both use the same functions | Proposed |
 | D3 | Response store, conversation manager, tool registry, and MCP client are implemented natively in Rust within `agentic-core` | Proposed |
-| D4 | Praxis integrates via a single thin adapter filter that delegates to `agentic-core` — deployed either as a backend service (network routing) or as an in-process library (linked filter) | Proposed |
-| D5 | Standalone mode (axum binary) is first-class, not an afterthought — same core code, different hosting | Proposed |
-| D6 | Each gateway adapter is one thin integration point (one filter/plugin), not a decomposition of domain logic across many filters | Proposed |
+| D4 | Praxis integrates via `agentic-praxis`, a filter that composes the default loop by calling `agentic-core` public functions — deployed either as a backend service or as an in-process library | Proposed |
+| D5 | Standalone mode (axum binary) is first-class — same core functions, different hosting | Proposed |
 
 ---
 
@@ -139,7 +140,7 @@ Thin axum wrapper. Parses HTTP, calls `agentic_core::execute()`, streams the res
 
 ### Layer 3: `agentic-praxis`
 
-One Praxis filter. Receives the HTTP request from Praxis, extracts the body, calls `agentic_core::execute()`, streams the response back through Praxis. The filter has no domain logic — it's pure plumbing.
+The default Praxis filter. Composes the agentic loop internally by calling `agentic-core` public functions. The out-of-the-box filter calls `execute()` for the standard loop. Consumers who need a custom loop (e.g. adding rate limiting before tool invocation, or inserting guardrails between inference and assembly) build their own filter that calls the individual step functions directly.
 
 Praxis depends on `agentic-praxis` as a crate, which transitively brings in `agentic-core`:
 
@@ -158,7 +159,7 @@ agentic-api publishes releases on its own schedule. Praxis bumps the version whe
 ### Praxis (production)
 
 ```
-Client → Praxis (auth, rate-limit, routing) → agentic-api service
+Client → Praxis (auth, rate-limit, routing) → agentic-server
                                                     │
                                                     ▼
                                               agentic-core
@@ -192,41 +193,67 @@ No gateway. Single binary. `agentic-api serve <model>` or `agentic-api --llm-api
 
 ### Other gateways (future)
 
-A Kong plugin, Envoy ext_proc adapter, or any other gateway integration follows the same pattern: thin adapter calling `agentic_core::execute()`. The core doesn't change.
+Praxis is what we start with. Because `agentic-core` functions are plain Rust with no gateway-specific API, supporting other gateways in the future is possible without changes to the core.
 
 ---
 
 ## Rationale
 
-### Single filter vs. decomposed filter chains
+### Two composition models from the same primitives
 
-An alternative integration model is to decompose the agentic loop into multiple Praxis filters (one per concern: conversation management, tool dispatch, loop control, inference calling). Both approaches are viable; we prefer the single-filter model for agentic-api.
+Because `agentic-core` exposes each loop step as a public function, two composition models are possible — both use the same underlying code.
 
-#### Decomposed filter chains
+#### Model A: Single filter (default)
 
-| Pros | Cons |
-|------|------|
-| Each concern is independently deployable and replaceable | Filters share state and depend on execution order — they are steps in a transaction, not independent cross-cutting concerns |
-| Praxis controls the full pipeline, enabling fine-grained observability per filter | Testing individual filters requires the full Praxis filter harness rather than plain `cargo test` |
-| Aligns with Praxis's long-term vision for re-entrant filter chains ([praxis#354](https://github.com/praxis-proxy/praxis/issues/354)) | Re-entrant chain support is still being developed in Praxis — building on it today introduces coupling to an evolving API |
-| Single deployment unit (one Praxis binary) | Harder to run standalone without Praxis |
+One Praxis filter composes the full loop internally by calling `agentic-core` functions:
 
-#### Single thin filter (our approach)
+```
+Client → Praxis filters (auth, rate-limit, routing)
+           → agentic-praxis filter
+               calls: rehydrate → inference → tool_dispatch → assemble → persist
+               (loop iteration is plain Rust control flow inside the filter)
+               (inference step calls vLLM internally; response returns to client)
+```
 
-| Pros | Cons |
-|------|------|
-| Core logic is testable with `cargo test` and the existing mock harness | Praxis has less visibility into the orchestration pipeline (it sees one filter, not the internal steps) |
-| The agentic loop is an explicit state machine — easy to reason about, debug, and extend | Requires a network hop in service mode (~1ms, negligible for LLM workloads) |
-| Works standalone (axum) or behind any gateway — not coupled to Praxis's filter API | Two deployment units in production (Praxis + agentic-api service) unless using in-process mode |
-| Adapter is thin (~50 lines), cheap to update if Praxis's filter API evolves | |
-| Praxis can still use `agentic-core` as an in-process library via the adapter filter — no network hop needed | |
+This is what `agentic-praxis` ships out of the box. The loop is self-contained, testable with `cargo test`, and works in standalone mode (axum) without Praxis.
 
-We choose the single-filter model because it keeps the orchestration core framework-agnostic, testable, and portable, while still offering Praxis native in-process integration via the adapter crate (D4, D6). As Praxis's re-entrant chain support matures, the integration model can be revisited.
+#### Model B: Per-step filter chain ([praxis#354](https://github.com/praxis-proxy/praxis/issues/354))
+
+Each `agentic-core` function is wrapped in its own Praxis filter. Praxis's re-entrant filter chains orchestrate the loop iteration:
+
+```
+Client → Praxis filters (auth, rate-limit, routing)
+           → conversation_retrieval filter  (calls rehydrate_conversation)
+           → pre_inference_guardrails filter
+           → inference filter               (calls call_inference)
+           → post_inference_guardrails filter
+           → tool_dispatch filter           (calls dispatch_tools)
+           → [re-enter chain if tool calls detected]
+           → response_assembly filter       (calls assemble_response)
+           → persistence filter             (calls persist_response)
+           → response to client
+           (inference filter calls vLLM internally)
+```
+
+Each filter wraps an `agentic-core` public function — the domain logic stays in `agentic-core`, the orchestration moves to Praxis's filter pipeline.
+
+#### Comparison
+
+| Concern | Model A (single filter) | Model B (per-step filters) |
+|---------|------------------------|---------------------------|
+| Loop control | Plain Rust control flow inside the filter | Praxis re-entrant filter chains |
+| Per-step customization | Call individual functions with custom logic between them | Insert custom filters between steps in the chain |
+| Observability | Explicit instrumentation inside the filter | Praxis provides per-filter metrics and tracing |
+| Standalone mode | Works as-is (axum) | Requires Praxis |
+| Praxis dependency | Runtime only (filter API) | Runtime + re-entrant chain support ([praxis#354](https://github.com/praxis-proxy/praxis/issues/354)) |
+| Testing | `cargo test` on `agentic-core` functions directly | `cargo test` on functions + Praxis filter harness for integration |
+
+Both models use the same `agentic-core` public functions. Model A is the starting point; Model B becomes available as Praxis's re-entrant chain support matures. The migration path is: wrap each function call in its own filter and move loop control to Praxis — no changes to `agentic-core`.
 
 ### Why three layers
 
 - **Testability.** Core logic is tested without any HTTP server or gateway infrastructure.
-- **Portability.** Adding a new gateway adapter means writing one thin crate, not porting the entire system.
+- **Composability.** Consumers can customize the agentic loop by wiring individual functions differently — adding steps, reordering, or replacing functions.
 - **Independent scaling.** As a service, agentic-api scales separately from the gateway. As an in-process filter, it shares the gateway's resources — the deployment choice is made at deploy time, not compile time.
 - **Release independence.** Core and server ship on their own schedule. Adapters depend on the core crate version, not on the gateway's release cycle.
 
@@ -284,8 +311,8 @@ If accepted, PR #27 should be closed in favor of this architecture.
 ## Implications
 
 - **Workspace migration.** The current flat crate structure (`src/`) will migrate to a Cargo workspace with `crates/agentic-core`, `crates/agentic-server`, and `crates/agentic-praxis`. This happens after PR #24 merges as a separate refactoring PR.
-- **Core API design.** The `agentic-core` public API (`execute()`, `ResponsesRequest`, `ResponseStream`, `ExecutionContext`) needs careful design — it's the contract that all adapters depend on.
-- **Praxis co-development.** We contribute `agentic-praxis` and work with the Praxis team to validate the backend routing model. This is simpler for both sides than re-entrant filter chains.
+- **Core API design.** The `agentic-core` public API (individual step functions, `execute()`, domain types) needs careful design — it's the contract that Praxis and any custom loop wiring depends on.
+- **Praxis co-development.** We contribute `agentic-praxis` and work with the Praxis team to validate the integration model. agentic-api is an early adopter that exercises Praxis's capabilities with a real agentic workload.
 - **State services.** Response store (ADR-02), conversation manager, and tool registry are implemented natively in Rust within `agentic-core`. No external Python services in the request path.
 
 ---

--- a/docs/adr/ADR-03_gateway_integration.md
+++ b/docs/adr/ADR-03_gateway_integration.md
@@ -1,0 +1,289 @@
+# ADR-03 — Gateway-Agnostic Layered Architecture
+
+> **Status:** Draft
+> **Related:** [ADR-01 — Core Architecture](ADR-01_core.md), [ADR-02 — Response Store](ADR-02_response_store.md), [PR #24](https://github.com/vllm-project/agentic-api/pull/24), [PR #27](https://github.com/vllm-project/agentic-api/pull/27)
+
+---
+
+## Intention
+
+This ADR settles:
+
+1. How agentic-api is structured as a crate workspace (three layers)
+2. How it integrates with gateway proxies (Praxis, and potentially others)
+3. Why the agentic loop is an explicit state machine, not proxy middleware
+
+---
+
+## Context
+
+Agentic-api is the orchestration core for the vLLM Responses API. It manages the agentic loop: conversation rehydration, inference calling, tool dispatch, response persistence. The question is how it relates to the gateway proxy that sits in front of it.
+
+### The gateway landscape
+
+Multiple gateway options exist: Praxis (Rust, early-stage, co-development opportunity), Kong, Envoy, or no gateway at all (standalone mode for development). Coupling the orchestration core to any single gateway's plugin API creates lock-in and limits adoption.
+
+### The integration question
+
+One integration model has been proposed: decompose the agentic loop into **Praxis re-entrant filter chains**. This spreads tightly coupled domain logic (conversation rehydration, tool dispatch, loop control, response assembly) across loosely coupled filters. These components share state, depend on execution order, and interact through response semantics — they are the core transaction, not cross-cutting concerns. Encoding them as filters makes the system harder to reason about, harder to test (requires full filter harness), and couples the release cycle to Praxis. Additionally, re-entrant filter chains don't exist in Praxis yet ([praxis#354](https://github.com/praxis-proxy/praxis/issues/354)).
+
+---
+
+## Decision
+
+### Three-layer crate architecture
+
+```
+┌─────────────────────────────────────────────┐
+│  Layer 3: Thin adapters (one per gateway)   │
+│                                             │
+│  ┌───────────┐ ┌───────┐ ┌──────┐ ┌─────┐   │
+│  │   axum    │ │Praxis │ │ Kong │ │ ... │   │
+│  │(standalone)│ filter │ │plugin│ │     │   │
+│  └───────────┘ └───────┘ └──────┘ └─────┘   │
+├─────────────────────────────────────────────┤
+│  Layer 2: HTTP API (service mode)           │
+│                                             │
+│  POST /v1/responses → calls into core       │
+│  SSE streaming, health checks               │
+├─────────────────────────────────────────────┤
+│  Layer 1: Core library                      │
+│  (pure Rust, no framework dependency)       │
+│                                             │
+│  Executor (loop state machine)              │
+│  Conversation manager                       │
+│  Response store (trait-based backends)      │
+│  Tool registry + dispatch                   │
+│  MCP client                                 │
+│  Inference caller                           │
+│  Response assembler                         │
+│                                             │
+│  No axum. No Praxis. No framework.          │
+│  Just async Rust + traits.                  │
+└─────────────────────────────────────────────┘
+```
+
+### Key decisions
+
+| # | Decision | Status |
+|---|----------|--------|
+| D1 | Core orchestration logic is a framework-agnostic Rust library crate (`agentic-core`) with no HTTP server or gateway dependencies | Proposed |
+| D2 | The agentic loop is an explicit async state machine in application code, not decomposed into proxy filter chains | Proposed |
+| D3 | Response store, conversation manager, tool registry, and MCP client are implemented natively in Rust within `agentic-core` | Proposed |
+| D4 | Praxis integrates via a single thin adapter filter that delegates to `agentic-core` — deployed either as a backend service (network routing) or as an in-process library (linked filter) | Proposed |
+| D5 | Standalone mode (axum binary) is first-class, not an afterthought — same core code, different hosting | Proposed |
+| D6 | Each gateway adapter is one thin integration point (one filter/plugin), not a decomposition of domain logic across many filters | Proposed |
+
+---
+
+## Crate Structure
+
+```
+agentic-api/
+  Cargo.toml              # [workspace]
+
+  crates/
+    agentic-core/          # Layer 1: pure library
+      Cargo.toml           # [lib], deps: tokio, reqwest, serde, sqlx
+      src/
+        lib.rs
+        executor.rs        # Loop state machine
+        store.rs           # Response store (trait + impls)
+        conversation.rs    # Conversation manager
+        inference.rs       # vLLM proxy / inference caller
+        tools/
+          mod.rs           # Tool registry + dispatch
+          mcp.rs           # MCP client (stdio/SSE)
+          builtin.rs       # web_search, file_search, code_interpreter
+          host.rs          # Sandboxed host tools
+
+    agentic-server/        # Layer 2: axum standalone binary
+      Cargo.toml           # depends on agentic-core
+      src/
+        main.rs            # CLI, axum server, vLLM subprocess mgmt
+
+    agentic-praxis/        # Layer 3: Praxis adapter
+      Cargo.toml           # depends on agentic-core + praxis
+      src/
+        lib.rs             # Single filter: receive request → core → stream response
+```
+
+### Layer 1: `agentic-core`
+
+The core crate exports an async function that takes a request and returns a response stream. No HTTP types, no framework types — just domain types.
+
+```rust
+pub async fn execute(
+    request: ResponsesRequest,
+    ctx: &ExecutionContext,  // holds store, tools, inference client
+) -> Result<ResponseStream, Error>
+```
+
+Dependencies: `tokio`, `reqwest`, `serde`, `serde_json`, `sqlx`, `thiserror`. No `axum`, no `praxis`, no `tower`, no `hyper`.
+
+### Layer 2: `agentic-server`
+
+Thin axum wrapper. Parses HTTP, calls `agentic_core::execute()`, streams the result. Owns the CLI (`clap`), vLLM subprocess management, and standalone server lifecycle. This is what PR #24 builds today.
+
+### Layer 3: `agentic-praxis`
+
+One Praxis filter. Receives the HTTP request from Praxis, extracts the body, calls `agentic_core::execute()`, streams the response back through Praxis. The filter has no domain logic — it's pure plumbing.
+
+Praxis depends on `agentic-praxis` as a crate, which transitively brings in `agentic-core`:
+
+```toml
+# In Praxis's Cargo.toml or a downstream build
+[dependencies]
+agentic-praxis = "0.1"  # pulls in agentic-core automatically
+```
+
+agentic-api publishes releases on its own schedule. Praxis bumps the version when ready.
+
+---
+
+## Integration Models
+
+### Praxis (production)
+
+```
+Client → Praxis (auth, rate-limit, routing) → agentic-api service
+                                                    │
+                                                    ▼
+                                              agentic-core
+                                                    │
+                                                    ▼
+                                              vLLM / llm-d
+```
+
+Praxis sees agentic-api as an HTTP backend — the same way it sees vLLM. For stateful requests (`previous_response_id`, tools), Praxis routes to agentic-api. For stateless pass-through, Praxis routes directly to vLLM.
+
+Alternatively, Praxis can link `agentic-praxis` as an in-process filter, eliminating the network hop while keeping the same core logic:
+
+```
+Client → Praxis (auth, rate-limit, routing, agentic-praxis filter) → vLLM
+                                                │
+                                          agentic-core
+                                          (in-process)
+```
+
+Both modes use the same `agentic-core` code. The choice is a deployment decision, not an architecture decision.
+
+### Standalone (development)
+
+```
+Client → agentic-server (axum) → vLLM (subprocess or external)
+                │
+          agentic-core
+```
+
+No gateway. Single binary. `agentic-api serve <model>` or `agentic-api --llm-api-base <url>`.
+
+### Other gateways (future)
+
+A Kong plugin, Envoy ext_proc adapter, or any other gateway integration follows the same pattern: thin adapter calling `agentic_core::execute()`. The core doesn't change.
+
+---
+
+## Rationale
+
+### Single filter vs. decomposed filter chains
+
+An alternative integration model is to decompose the agentic loop into multiple Praxis filters (one per concern: conversation management, tool dispatch, loop control, inference calling). Both approaches are viable; we prefer the single-filter model for agentic-api.
+
+#### Decomposed filter chains
+
+| Pros | Cons |
+|------|------|
+| Each concern is independently deployable and replaceable | Filters share state and depend on execution order — they are steps in a transaction, not independent cross-cutting concerns |
+| Praxis controls the full pipeline, enabling fine-grained observability per filter | Testing individual filters requires the full Praxis filter harness rather than plain `cargo test` |
+| Aligns with Praxis's long-term vision for re-entrant filter chains ([praxis#354](https://github.com/praxis-proxy/praxis/issues/354)) | Re-entrant chain support is still being developed in Praxis — building on it today introduces coupling to an evolving API |
+| Single deployment unit (one Praxis binary) | Harder to run standalone without Praxis |
+
+#### Single thin filter (our approach)
+
+| Pros | Cons |
+|------|------|
+| Core logic is testable with `cargo test` and the existing mock harness | Praxis has less visibility into the orchestration pipeline (it sees one filter, not the internal steps) |
+| The agentic loop is an explicit state machine — easy to reason about, debug, and extend | Requires a network hop in service mode (~1ms, negligible for LLM workloads) |
+| Works standalone (axum) or behind any gateway — not coupled to Praxis's filter API | Two deployment units in production (Praxis + agentic-api service) unless using in-process mode |
+| Adapter is thin (~50 lines), cheap to update if Praxis's filter API evolves | |
+| Praxis can still use `agentic-core` as an in-process library via the adapter filter — no network hop needed | |
+
+We choose the single-filter model because it keeps the orchestration core framework-agnostic, testable, and portable, while still offering Praxis native in-process integration via the adapter crate (D4, D6). As Praxis's re-entrant chain support matures, the integration model can be revisited.
+
+### Why three layers
+
+- **Testability.** Core logic is tested without any HTTP server or gateway infrastructure.
+- **Portability.** Adding a new gateway adapter means writing one thin crate, not porting the entire system.
+- **Independent scaling.** As a service, agentic-api scales separately from the gateway. As an in-process filter, it shares the gateway's resources — the deployment choice is made at deploy time, not compile time.
+- **Release independence.** Core and server ship on their own schedule. Adapters depend on the core crate version, not on the gateway's release cycle.
+
+---
+
+## Deployment Modes
+
+```
+MODE 1: Dev / standalone             MODE 2: Production (service)
+──────────────────────               ────────────────────────────
+
+  Client                               Client
+    │                                    │
+    ▼                                    ▼
+  agentic-server (axum)                Praxis (Rust gateway)
+    │  single binary                     │  auth, rate-limit,
+    │  no gateway needed                 │  routing, guardrails
+    ▼                                    ▼
+  vLLM (subprocess                     agentic-server (Rust service)
+    or external)                         │
+                                         ▼
+                                       vLLM / llm-d (fleet)
+
+
+MODE 3: Production (in-process)
+───────────────────────────────
+
+  Client
+    │
+    ▼
+  Praxis (with agentic-praxis filter linked)
+    │  gateway filters + agentic core in one process
+    ▼
+  vLLM / llm-d (fleet)
+```
+
+---
+
+## Impact on Existing PRs
+
+### PR #24 — Rust proxy gateway
+
+PR #24 becomes the foundation of `agentic-core` and `agentic-server`. The proxy logic (`proxy.rs`), configuration (`config.rs`), error handling (`error.rs`), and CLI (`main.rs`) evolve into the layered crate structure. The standalone `serve` mode remains first-class in `agentic-server`. Benchmarks stay.
+
+The workspace migration (flat crate → workspace with `crates/`) is a follow-up after PR #24 merges. PR #24 ships as-is — it's correct and complete for the current scope.
+
+### PR #27 — Praxis filter-based architecture
+
+PR #27 decomposes the agentic loop into multiple Praxis filters (`responses_proxy`, `agentic_loop`, `state_hydration`, `tool_dispatch`). This ADR supersedes that approach: the loop stays as an explicit state machine in `agentic-core`, and the Praxis integration is a single thin filter in `agentic-praxis`.
+
+PR #27 should be closed in favor of this architecture.
+
+---
+
+## Implications
+
+- **Workspace migration.** The current flat crate structure (`src/`) will migrate to a Cargo workspace with `crates/agentic-core`, `crates/agentic-server`, and `crates/agentic-praxis`. This happens after PR #24 merges as a separate refactoring PR.
+- **Core API design.** The `agentic-core` public API (`execute()`, `ResponsesRequest`, `ResponseStream`, `ExecutionContext`) needs careful design — it's the contract that all adapters depend on.
+- **Praxis co-development.** We contribute `agentic-praxis` and work with the Praxis team to validate the backend routing model. This is simpler for both sides than re-entrant filter chains.
+- **State services.** Response store (ADR-02), conversation manager, and tool registry are implemented natively in Rust within `agentic-core`. No external Python services in the request path.
+
+---
+
+## Open Questions
+
+1. **Praxis filter API stability.** The `HttpFilter` trait and `HttpFilterContext` API are young. How stable is the contract we build the adapter against? Mitigation: the adapter is thin (~50 lines), so API changes are cheap to absorb.
+
+2. **Built-in tool implementation.** `web_search`, `file_search`, `code_interpreter` are listed as Rust-native. These are non-trivial to implement. What's the MVP subset? Likely: MCP client first (delegates to external tool servers), built-in tools later.
+
+3. **Guardrails integration point.** Input guardrails can run in Praxis (pre-routing) or in agentic-api (post-hydration, with full conversation context). Output guardrails must run in agentic-api (per loop iteration). The split needs to be validated with the guardrails team.
+
+4. **In-process vs service mode trade-offs.** Mode 2 (service) adds ~1ms per loop iteration but gives process isolation and independent scaling. Mode 3 (in-process) eliminates the hop but shares failure domains. Which is the default recommendation for production?


### PR DESCRIPTION
## Summary

Adds ADR-03 which captures the architectural decision for how agentic-api integrates with gateway proxies (Praxis, Kong, etc.). Defines a three-layer crate structure: core library (`agentic-core`), HTTP server (`agentic-server`), and thin gateway adapters (`agentic-praxis`). The agentic loop is an explicit Rust state machine rather than decomposed into proxy filter chains. Includes a balanced comparison of both approaches with pros/cons.

## Test Plan

- Documentation-only change, no code impact.
- ADR reviewed iteratively for technical accuracy and tone.