### PR TITLE
docs: add pre-commit install to setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,10 @@ This repository is Rust-first under the `vllm-project` GitHub organization.
 
 ## Setup
 
-Build the project:
+Install pre-commit hooks and build the project:
 
 ```bash
+pre-commit install
 cargo build
 ```
 


### PR DESCRIPTION
## Summary

- Adds `pre-commit install` to the Setup section in AGENTS.md so new contributors get git hooks installed before their first commit

## Test plan

- [x] Verified `pre-commit install` sets up `.git/hooks/pre-commit`
- [x] Verified hooks run automatically on `git commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)