### PR TITLE
feat: add /health and /ready endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,8 +583,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -589,7 +611,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -731,6 +753,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -991,6 +1014,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,6 +1232,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,6 +1260,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,9 +1325,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rayon"
@@ -1319,6 +1447,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1326,6 +1456,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -1335,6 +1466,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1350,6 +1482,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -1371,6 +1509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1383,6 +1522,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1706,6 +1846,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2089,6 +2244,25 @@ checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/crates/agentic-server/Cargo.toml
+++ b/crates/agentic-server/Cargo.toml
@@ -11,6 +11,7 @@ agentic-core = { path = "../agentic-core" }
 axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 http = "1"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["cors"] }

--- a/crates/agentic-server/src/app.rs
+++ b/crates/agentic-server/src/app.rs
@@ -1,11 +1,13 @@
 use agentic_core::proxy::ProxyState;
 use axum::Router;
-use axum::routing::post;
+use axum::routing::{get, post};
 
-use crate::handler::proxy_responses;
+use crate::handler::{health, proxy_responses, ready};
 
 pub fn build_router(state: ProxyState) -> Router {
     Router::new()
+        .route("/health", get(health))
+        .route("/ready", get(ready))
         .route("/v1/responses", post(proxy_responses))
         .with_state(state)
 }

--- a/crates/agentic-server/src/handler.rs
+++ b/crates/agentic-server/src/handler.rs
@@ -1,10 +1,40 @@
 use agentic_core::proxy::{ProxyBody, ProxyRequest, ProxyResponse, ProxyState, error_response};
 use axum::body::Body;
 use axum::extract::State;
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use http::StatusCode;
+use tracing::warn;
 
 const MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
+
+pub async fn health() -> impl IntoResponse {
+    StatusCode::OK
+}
+
+pub async fn ready(State(state): State<ProxyState>) -> impl IntoResponse {
+    let base = state.config.llm_api_base.trim_end_matches('/');
+    let url = format!("{base}/health");
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(2))
+        .build();
+
+    let Ok(client) = client else {
+        return StatusCode::SERVICE_UNAVAILABLE;
+    };
+
+    match client.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => StatusCode::OK,
+        Ok(resp) => {
+            warn!("LLM backend not ready: status {}", resp.status());
+            StatusCode::SERVICE_UNAVAILABLE
+        }
+        Err(e) => {
+            warn!("LLM backend unreachable: {e}");
+            StatusCode::SERVICE_UNAVAILABLE
+        }
+    }
+}
 
 fn convert_response(resp: ProxyResponse) -> Response {
     let mut builder = Response::builder().status(resp.status);

--- a/crates/agentic-server/src/handler.rs
+++ b/crates/agentic-server/src/handler.rs
@@ -15,8 +15,19 @@ pub async fn ready(State(state): State<ProxyState>) -> impl IntoResponse {
     let base = state.config.llm_api_base.trim_end_matches('/');
     let url = format!("{base}/health");
 
+    let mut headers = reqwest::header::HeaderMap::new();
+    if let Some(key) = state.config.openai_api_key.as_deref() {
+        let trimmed = key.trim();
+        if !trimmed.is_empty() {
+            if let Ok(v) = reqwest::header::HeaderValue::from_str(&format!("Bearer {trimmed}")) {
+                headers.insert(reqwest::header::AUTHORIZATION, v);
+            }
+        }
+    }
+
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(2))
+        .default_headers(headers)
         .build();
 
     let Ok(client) = client else {

--- a/crates/agentic-server/tests/health_test.rs
+++ b/crates/agentic-server/tests/health_test.rs
@@ -1,0 +1,91 @@
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::Router;
+use http::StatusCode;
+use tokio::net::TcpListener;
+
+use agentic_core::config::Config;
+use agentic_core::proxy::ProxyState;
+
+fn test_config(llm_url: &str) -> Config {
+    Config {
+        llm_api_base: llm_url.to_owned(),
+        openai_api_key: Some("env-llm-key".to_owned()),
+        llm_ready_timeout_s: 5.0,
+        llm_ready_interval_s: 0.1,
+    }
+}
+
+fn test_config_no_key(llm_url: &str) -> Config {
+    Config {
+        openai_api_key: None,
+        ..test_config(llm_url)
+    }
+}
+
+async fn spawn_mock_llm() -> (String, tokio::task::JoinHandle<()>) {
+    let app = Router::new().route("/health", get(|| async { StatusCode::OK.into_response() }));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), handle)
+}
+
+async fn spawn_gateway(config: Config) -> (String, tokio::task::JoinHandle<()>) {
+    let state = ProxyState::new(config).unwrap();
+    let router = agentic_server::app::build_router(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+    (format!("http://{addr}"), handle)
+}
+
+#[tokio::test]
+async fn test_health_returns_200() {
+    let (llm_url, _h1) = spawn_mock_llm().await;
+    let config = test_config(&llm_url);
+    let (gw_url, _h2) = spawn_gateway(config).await;
+
+    let resp = reqwest::get(format!("{gw_url}/health")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn test_health_returns_200_even_when_llm_down() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let dead_addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let config = test_config_no_key(&format!("http://{dead_addr}"));
+    let (gw_url, _h2) = spawn_gateway(config).await;
+
+    let resp = reqwest::get(format!("{gw_url}/health")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn test_ready_returns_200_when_llm_healthy() {
+    let (llm_url, _h1) = spawn_mock_llm().await;
+    let config = test_config(&llm_url);
+    let (gw_url, _h2) = spawn_gateway(config).await;
+
+    let resp = reqwest::get(format!("{gw_url}/ready")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn test_ready_returns_503_when_llm_unreachable() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let dead_addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let config = test_config_no_key(&format!("http://{dead_addr}"));
+    let (gw_url, _h2) = spawn_gateway(config).await;
+
+    let resp = reqwest::get(format!("{gw_url}/ready")).await.unwrap();
+    assert_eq!(resp.status(), 503);
+}

--- a/crates/agentic-server/tests/health_test.rs
+++ b/crates/agentic-server/tests/health_test.rs
@@ -1,6 +1,6 @@
+use axum::Router;
 use axum::response::IntoResponse;
 use axum::routing::get;
-use axum::Router;
 use http::StatusCode;
 use tokio::net::TcpListener;
 


### PR DESCRIPTION
## Summary

Add liveness (`GET /health`) and readiness (`GET /ready`) endpoints to the gateway, enabling proper orchestration under Kubernetes, ECS, and docker-compose.

- `/health` returns `200 OK` unconditionally when the process is listening (liveness probe)
- `/ready` probes the LLM backend's `/health` with a 2-second timeout and returns `200` if healthy, `503 Service Unavailable` otherwise (readiness probe)

This separates "is the gateway process alive?" from "is the system ready to serve traffic?" — standard for any load-balanced deployment.

Closes #31

## Related

- Follow-up from [PR #29 review comment](https://github.com/vllm-project/agentic-api/pull/29#pullrequestreview-4368002235) — @leseb acknowledged as a sensible follow-up
- Pattern aligned with [vllm#36960](https://github.com/vllm-project/vllm/issues/36960) (vLLM health endpoint conventions)

## Changes

| File | Change |
|------|--------|
| `crates/agentic-server/src/handler.rs` | `health()` and `ready()` handler functions |
| `crates/agentic-server/src/app.rs` | Route registration for `/health` and `/ready` |
| `crates/agentic-server/Cargo.toml` | Add `reqwest` runtime dependency (for backend probe) |
| `crates/agentic-server/tests/health_test.rs` | 4 integration tests |

## Test Plan

**Automated (4 integration tests):**
- `test_health_returns_200` — gateway up, LLM up → 200
- `test_health_returns_200_even_when_llm_down` — gateway up, LLM unreachable → 200 (liveness unaffected)
- `test_ready_returns_200_when_llm_healthy` — LLM responds on `/health` → 200
- `test_ready_returns_503_when_llm_unreachable` — LLM unreachable → 503

All pass via `cargo test --workspace`.

**Manual (live vLLM backend):**
Built the gateway on an EC2 g6e.48xlarge instance and pointed it at a running vLLM server (port 8000):
```
$ curl -w '%{http_code}' http://localhost:9090/health
200
$ curl -w '%{http_code}' http://localhost:9090/ready
200
```

**Lint/format:**
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt -- --check` — clean