### PR TITLE
feat: add CORS support to gateway

### DIFF
--- a/crates/agentic-server/benches/proxy_bench.rs
+++ b/crates/agentic-server/benches/proxy_bench.rs
@@ -14,7 +14,7 @@ use tokio::runtime::Runtime;
 
 use agentic_core::config::Config;
 use agentic_core::proxy::ProxyState;
-use agentic_server::app::build_router;
+use agentic_server::app::{ServerConfig, build_router};
 
 fn bench_config(llm_url: &str) -> Config {
     Config {
@@ -72,7 +72,8 @@ async fn spawn_llm() -> String {
 
 async fn spawn_gateway(config: Config) -> String {
     let state = ProxyState::new(config).unwrap();
-    let router = build_router(state);
+    let server_config = ServerConfig::from_env();
+    let router = build_router(state, &server_config);
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/crates/agentic-server/src/app.rs
+++ b/crates/agentic-server/src/app.rs
@@ -1,13 +1,17 @@
 use agentic_core::proxy::ProxyState;
 use axum::Router;
 use axum::routing::{get, post};
+use tower_http::cors::{Any, CorsLayer};
 
 use crate::handler::{health, proxy_responses, ready};
 
 pub fn build_router(state: ProxyState) -> Router {
+    let cors = CorsLayer::new().allow_origin(Any).allow_methods(Any).allow_headers(Any);
+
     Router::new()
         .route("/health", get(health))
         .route("/ready", get(ready))
         .route("/v1/responses", post(proxy_responses))
+        .layer(cors)
         .with_state(state)
 }

--- a/crates/agentic-server/src/app.rs
+++ b/crates/agentic-server/src/app.rs
@@ -1,17 +1,57 @@
 use agentic_core::proxy::ProxyState;
 use axum::Router;
 use axum::routing::{get, post};
-use tower_http::cors::{Any, CorsLayer};
+use http::HeaderValue;
+use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 
 use crate::handler::{health, proxy_responses, ready};
 
-pub fn build_router(state: ProxyState) -> Router {
-    let cors = CorsLayer::new().allow_origin(Any).allow_methods(Any).allow_headers(Any);
+/// Server-level configuration read from environment variables.
+pub struct ServerConfig {
+    pub cors_allowed_origins: Vec<String>,
+}
 
+impl ServerConfig {
+    /// Read `CORS_ALLOWED_ORIGINS` (comma-separated). Unset or empty = permissive.
+    #[must_use]
+    pub fn from_env() -> Self {
+        let cors_allowed_origins = std::env::var("CORS_ALLOWED_ORIGINS")
+            .ok()
+            .map(|s| {
+                s.split(',')
+                    .map(str::trim)
+                    .filter(|o| !o.is_empty())
+                    .map(str::to_owned)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        Self { cors_allowed_origins }
+    }
+
+    fn cors_layer(&self) -> CorsLayer {
+        let allow_origin = if self.cors_allowed_origins.is_empty() {
+            AllowOrigin::any()
+        } else {
+            let origins: Vec<HeaderValue> = self
+                .cors_allowed_origins
+                .iter()
+                .filter_map(|o| o.parse().ok())
+                .collect();
+            AllowOrigin::list(origins)
+        };
+
+        CorsLayer::new()
+            .allow_origin(allow_origin)
+            .allow_methods(Any)
+            .allow_headers(Any)
+    }
+}
+
+pub fn build_router(state: ProxyState, server_config: &ServerConfig) -> Router {
     Router::new()
         .route("/health", get(health))
         .route("/ready", get(ready))
         .route("/v1/responses", post(proxy_responses))
-        .layer(cors)
+        .layer(server_config.cors_layer())
         .with_state(state)
 }

--- a/crates/agentic-server/src/server.rs
+++ b/crates/agentic-server/src/server.rs
@@ -2,14 +2,15 @@ use agentic_core::config::Config;
 use agentic_core::error::Error;
 use agentic_core::proxy::ProxyState;
 use agentic_core::readiness::wait_llm_ready;
-use agentic_server::app::build_router;
+use agentic_server::app::{ServerConfig, build_router};
 use tokio::net::TcpListener;
 use tracing::info;
 
 async fn serve_gateway(config: Config, host: &str, port: u16) -> Result<(), Error> {
     let addr = format!("{host}:{port}");
     let state = ProxyState::new(config)?;
-    let router = build_router(state);
+    let server_config = ServerConfig::from_env();
+    let router = build_router(state, &server_config);
     let listener = TcpListener::bind(&addr).await?;
     info!("gateway listening on {addr}");
     axum::serve(listener, router).await?;

--- a/crates/agentic-server/tests/cors_test.rs
+++ b/crates/agentic-server/tests/cors_test.rs
@@ -28,7 +28,8 @@ async fn spawn_mock_llm() -> (String, tokio::task::JoinHandle<()>) {
 
 async fn spawn_gateway(config: Config) -> (String, tokio::task::JoinHandle<()>) {
     let state = ProxyState::new(config).unwrap();
-    let router = agentic_server::app::build_router(state);
+    let server_config = agentic_server::app::ServerConfig::from_env();
+    let router = agentic_server::app::build_router(state, &server_config);
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let handle = tokio::spawn(async move {

--- a/crates/agentic-server/tests/cors_test.rs
+++ b/crates/agentic-server/tests/cors_test.rs
@@ -1,0 +1,79 @@
+use axum::Router;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use http::StatusCode;
+use tokio::net::TcpListener;
+
+use agentic_core::config::Config;
+use agentic_core::proxy::ProxyState;
+
+fn test_config(llm_url: &str) -> Config {
+    Config {
+        llm_api_base: llm_url.to_owned(),
+        openai_api_key: None,
+        llm_ready_timeout_s: 5.0,
+        llm_ready_interval_s: 0.1,
+    }
+}
+
+async fn spawn_mock_llm() -> (String, tokio::task::JoinHandle<()>) {
+    let app = Router::new().route("/health", get(|| async { StatusCode::OK.into_response() }));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), handle)
+}
+
+async fn spawn_gateway(config: Config) -> (String, tokio::task::JoinHandle<()>) {
+    let state = ProxyState::new(config).unwrap();
+    let router = agentic_server::app::build_router(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+    (format!("http://{addr}"), handle)
+}
+
+#[tokio::test]
+async fn test_cors_preflight_returns_200() {
+    let (llm_url, _h1) = spawn_mock_llm().await;
+    let config = test_config(&llm_url);
+    let (gw_url, _h2) = spawn_gateway(config).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .request(reqwest::Method::OPTIONS, format!("{gw_url}/v1/responses"))
+        .header("Origin", "http://example.com")
+        .header("Access-Control-Request-Method", "POST")
+        .header("Access-Control-Request-Headers", "Content-Type,Authorization")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    assert!(resp.headers().contains_key("access-control-allow-origin"));
+    assert!(resp.headers().contains_key("access-control-allow-methods"));
+    assert!(resp.headers().contains_key("access-control-allow-headers"));
+}
+
+#[tokio::test]
+async fn test_cors_headers_on_regular_request() {
+    let (llm_url, _h1) = spawn_mock_llm().await;
+    let config = test_config(&llm_url);
+    let (gw_url, _h2) = spawn_gateway(config).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{gw_url}/v1/responses"))
+        .header("Origin", "http://example.com")
+        .header("Content-Type", "application/json")
+        .body(r#"{"model":"test","input":"hi"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    assert!(resp.headers().contains_key("access-control-allow-origin"));
+}

--- a/crates/agentic-server/tests/health_test.rs
+++ b/crates/agentic-server/tests/health_test.rs
@@ -35,7 +35,8 @@ async fn spawn_mock_llm() -> (String, tokio::task::JoinHandle<()>) {
 
 async fn spawn_gateway(config: Config) -> (String, tokio::task::JoinHandle<()>) {
     let state = ProxyState::new(config).unwrap();
-    let router = agentic_server::app::build_router(state);
+    let server_config = agentic_server::app::ServerConfig::from_env();
+    let router = agentic_server::app::build_router(state, &server_config);
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let handle = tokio::spawn(async move {


### PR DESCRIPTION
## Summary

Wire `tower-http` `CorsLayer` into the router with configurable origin restrictions via the `CORS_ALLOWED_ORIGINS` environment variable.

- **Unset or empty** → permissive (allow any origin) — suitable for local dev, playground UIs, Swagger
- **Set** → comma-separated list of allowed origins (e.g., `CORS_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com`)

Adds a `ServerConfig` struct that reads CORS configuration from the environment at startup and passes it to `build_router`.

Closes #38

## Configuration

| Env Var | Default | Effect |
|---------|---------|--------|
| `CORS_ALLOWED_ORIGINS` | (unset) | Allow any origin (permissive) |
| `CORS_ALLOWED_ORIGINS=https://app.example.com` | — | Only that origin allowed |
| `CORS_ALLOWED_ORIGINS=https://a.com,https://b.com` | — | Both origins allowed |

Methods and headers are always permissive (`Any`) regardless of origin setting.

## Test Plan

**Automated (2 integration tests):**
- `test_cors_preflight_returns_200` — OPTIONS with Origin + Access-Control-Request-Method → 200 with all CORS headers
- `test_cors_headers_on_regular_request` — POST with Origin → response includes `access-control-allow-origin`

```
cargo test --workspace
# 31 tests pass (23 unit + 2 main + 4 health + 2 CORS)
```

**Lint/format:**
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt -- --check` — clean

**Discovery:** Found via live stress testing against deployed gateway on EC2 (see #38 for reproduction).