### PR TITLE
docs: add sccache shared build cache section to getting started

### DIFF
--- a/docs/developing/getting-started.md
+++ b/docs/developing/getting-started.md
@@ -1,0 +1,74 @@
+# Getting Started
+
+## Prerequisites
+
+- Rust toolchain (MSRV 1.85)
+- [pre-commit](https://pre-commit.com/)
+
+## Building
+
+Install pre-commit hooks and build the project:
+
+```console
+pre-commit install
+cargo build
+```
+
+## Testing
+
+```console
+cargo test
+```
+
+## Linting and Formatting
+
+```console
+cargo clippy --all-targets -- -D warnings   # lint
+cargo fmt                                     # format
+cargo fmt -- --check                          # check formatting only
+```
+
+To run all pre-commit hooks manually:
+
+```console
+pre-commit run --all-files
+```
+
+## Shared Build Cache with sccache
+
+[sccache] caches compiled artifacts so that switching
+branches, cleaning `target/`, or working across
+multiple git worktrees does not require rebuilding
+every dependency from scratch.
+
+### Setup
+
+[Install sccache][sccache-install], then add the
+following to your shell profile (`~/.bashrc`,
+`~/.zshrc`, etc.):
+
+```sh
+export RUSTC_WRAPPER=$(which sccache)
+```
+
+### Warming the cache
+
+After setting up sccache, run a full clippy pass in any
+worktree to populate the cache:
+
+```console
+cargo clippy --workspace --all-targets
+```
+
+Subsequent builds reuse the cached artifacts
+automatically. Cargo still prints `Compiling` /
+`Checking` for every crate, but cache-hit compilations
+complete in milliseconds instead of seconds.
+
+Check hit rates with `sccache --show-stats`. See
+[sccache usage][sccache-usage] for more configuration
+options.
+
+[sccache]: https://github.com/mozilla/sccache
+[sccache-install]: https://github.com/mozilla/sccache#installation
+[sccache-usage]: https://github.com/mozilla/sccache#usage

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -92,6 +92,8 @@ markdown_extensions:
 nav:
   - Home: index.md
   - API Reference: api/index.md
+  - Developing:
+    - Getting Started: developing/getting-started.md
   - Community: community/index.md
 
 extra:


### PR DESCRIPTION
## Summary

- Adds a new "Developing" section to the MkDocs documentation with a getting-started guide
- Documents sccache setup, cache warming, and links to upstream sccache docs for installation and configuration
- Helps contributors avoid full dependency rebuilds when switching branches or working across worktrees

Similar to https://github.com/praxis-proxy/praxis/pull/468.

## Test plan

- [x] `mkdocs build --strict` passes with no errors
- [ ] Verify the doc renders correctly on GitHub
- [ ] Follow the setup instructions on a fresh checkout to confirm they work

🤖 Generated with [Claude Code](https://claude.com/claude-code)