### PR TITLE
fix: preserve response hydration checkpoints

### DIFF
--- a/crates/agentic-core/src/executor/engine.rs
+++ b/crates/agentic-core/src/executor/engine.rs
@@ -116,11 +116,10 @@ async fn fetch_response_json(
 /// for `original_request` so the engine retains an unmodified copy for persistence
 /// and ID resolution.
 ///
-/// Dispatches to one of four paths based on `store` flag and which ID is present:
-/// - `store=false` + `previous_response_id`: validate the prior response exists, no history loaded
-/// - `store=true`  + `previous_response_id`: [`rehydrate_from_response`]
-/// - `store=true`  + `conversation_id`:      [`rehydrate_from_conversation`]
-/// - `store=true`  + no ids:                 create a new conversation
+/// Dispatches based on `store` flag and which ID is present:
+/// - `previous_response_id`: rehydrate from the prior response checkpoint
+/// - `conversation_id`:      rehydrate from the conversation
+/// - no ids:                 forward only the new input
 ///
 /// # Errors
 /// Returns [`ExecutorError`] if storage is unavailable or a referenced ID does not exist.
@@ -141,12 +140,10 @@ pub async fn rehydrate_conversation(
         conversation_id: None,
     };
 
-    if !ctx.original_request.store {
-        // Non-store path: validate previous_response_id only; no history needed.
-        if ctx.original_request.previous_response_id.is_some() {
-            exec_ctx.resp_handler.validate_exists(&ctx).await?;
-        }
-        return Ok(ctx);
+    if ctx.original_request.conversation_id.is_some() && ctx.original_request.previous_response_id.is_some() {
+        return Err(ExecutorError::InvalidRequest(
+            "provide only one of conversation_id or previous_response_id".into(),
+        ));
     }
 
     if ctx.original_request.conversation_id.is_some() {
@@ -159,9 +156,6 @@ pub async fn rehydrate_conversation(
         return Ok(ctx);
     }
 
-    // Store + no ids: create a fresh conversation.
-    let conv_data = exec_ctx.conv_handler.create().await?;
-    ctx.conversation_id = Some(conv_data.conversation_id);
     ctx.enriched_request.input = ResponsesInput::Items(ctx.new_input_items.clone());
     Ok(ctx)
 }
@@ -197,11 +191,17 @@ async fn rehydrate_from_response(ctx: &mut RequestContext, exec_ctx: &ExecutionC
 
 /// Hydrates `ctx` from the conversation store.
 ///
-/// Gets or creates the conversation and rehydrates its history in parallel,
-/// then prepends the history items to the enriched request input.
+/// Gets or creates the conversation (depending on `store`) and rehydrates its
+/// history in parallel, then prepends the history items to the enriched request input.
 async fn rehydrate_from_conversation(ctx: &mut RequestContext, exec_ctx: &ExecutionContext) -> ExecutorResult<()> {
     let (conv_data, history) = tokio::try_join!(
-        exec_ctx.conv_handler.get_or_create(ctx),
+        async {
+            if ctx.original_request.store {
+                exec_ctx.conv_handler.get_or_create(ctx).await
+            } else {
+                exec_ctx.conv_handler.get(ctx).await
+            }
+        },
         exec_ctx.conv_handler.rehydrate(ctx),
     )?;
 

--- a/crates/agentic-core/src/executor/modes/conversation.rs
+++ b/crates/agentic-core/src/executor/modes/conversation.rs
@@ -34,6 +34,22 @@ impl ConversationHandler {
         self.store.get_or_create(conv_id).await.map_err(ExecutorError::Storage)
     }
 
+    /// Gets an existing conversation.
+    ///
+    /// Reads `conversation_id` from `ctx.original_request`.
+    ///
+    /// # Errors
+    /// Returns `ExecutorError` if `conversation_id` is absent, the store is
+    /// disabled, the conversation does not exist, or the database query fails.
+    pub async fn get(&self, ctx: &RequestContext) -> ExecutorResult<ConversationData> {
+        let conv_id = ctx
+            .original_request
+            .conversation_id
+            .as_deref()
+            .ok_or_else(|| ExecutorError::InvalidRequest("conversation_id is required for get".into()))?;
+        self.store.get(conv_id).await.map_err(ExecutorError::Storage)
+    }
+
     /// Creates a brand-new conversation with a freshly generated ID.
     ///
     /// # Errors
@@ -150,6 +166,12 @@ mod tests {
     #[tokio::test]
     async fn test_get_or_create_disabled_store_returns_error() {
         let result = disabled_handler().get_or_create(&make_ctx(Some("conv_1"))).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_disabled_store_returns_error() {
+        let result = disabled_handler().get(&make_ctx(Some("conv_1"))).await;
         assert!(result.is_err());
     }
 

--- a/crates/agentic-core/src/storage/response.rs
+++ b/crates/agentic-core/src/storage/response.rs
@@ -100,7 +100,10 @@ impl ResponseStore {
     ) -> StoreResult<()> {
         let pool = self.pool()?;
 
-        let mut item_ids: Vec<String> = Vec::new();
+        let mut item_ids: Vec<String> = match previous_response_id {
+            Some(prev_id) => self.get(prev_id).await?.history_item_ids,
+            None => Vec::new(),
+        };
         let mut items_: Vec<(String, String)> = Vec::new();
         for any_item in new_items {
             let item_id = uuid7_str("item_");

--- a/crates/agentic-core/src/storage/types/item.rs
+++ b/crates/agentic-core/src/storage/types/item.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use serde::{Deserialize, Serialize};
 
 use crate::storage::StorageError;
-use crate::types::io::{InputItem, OutputItem};
+use crate::types::io::{InputItem, InputMessage, InputMessageContent, OutputItem};
 use crate::utils::common::serialize_to_string;
 
 /// Item kind (input vs output) for storage and retrieval.
@@ -47,14 +47,21 @@ impl TryFrom<&InOutItem> for String {
 }
 
 impl InOutItem {
-    /// Extracts input items from a mixed history, filtering out output items.
+    /// Converts stored history into input items suitable for a model request.
     #[must_use]
     pub fn into_input_items(history: Vec<InOutItem>) -> Vec<InputItem> {
         history
             .into_iter()
             .filter_map(|i| match i {
                 InOutItem::Input(item) => Some(item),
-                InOutItem::Output(_) => None,
+                InOutItem::Output(OutputItem::Message(msg)) => {
+                    let text = msg.content.into_iter().map(|content| content.text).collect::<String>();
+                    Some(InputItem::Message(InputMessage {
+                        role: msg.role,
+                        content: InputMessageContent::Text(text),
+                    }))
+                }
+                InOutItem::Output(OutputItem::FunctionCall(_) | OutputItem::Unknown) => None,
             })
             .collect()
     }
@@ -63,7 +70,7 @@ impl InOutItem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::io::{InputMessage, InputMessageContent, OutputMessage};
+    use crate::types::io::{OutputMessage, OutputTextContent};
 
     #[test]
     fn test_inout_item_from_input() {
@@ -95,21 +102,30 @@ mod tests {
     }
 
     #[test]
-    fn test_into_input_items_filters_outputs() {
+    fn test_into_input_items_converts_output_messages() {
+        let mut output = OutputMessage::new("out1", "done");
+        output.content.push(OutputTextContent::new("answer"));
         let items = vec![
             InOutItem::Input(InputItem::Message(InputMessage {
                 role: "user".to_string(),
                 content: InputMessageContent::Text("msg1".to_string()),
             })),
-            InOutItem::Output(OutputItem::Message(OutputMessage::new("out1", "done"))),
+            InOutItem::Output(OutputItem::Message(output)),
             InOutItem::Input(InputItem::Message(InputMessage {
-                role: "assistant".to_string(),
+                role: "user".to_string(),
                 content: InputMessageContent::Text("msg2".to_string()),
             })),
         ];
 
         let inputs = InOutItem::into_input_items(items);
-        assert_eq!(inputs.len(), 2);
+        assert_eq!(inputs.len(), 3);
+        match &inputs[1] {
+            InputItem::Message(message) => {
+                assert_eq!(message.role, "assistant");
+                assert!(matches!(&message.content, InputMessageContent::Text(text) if text == "answer"));
+            }
+            InputItem::FunctionCallOutput(_) | InputItem::Unknown => panic!("expected message"),
+        }
     }
 
     #[test]

--- a/crates/agentic-core/tests/stateful_conversation_integration.rs
+++ b/crates/agentic-core/tests/stateful_conversation_integration.rs
@@ -9,8 +9,8 @@ mod support;
 use agentic_core::executor::{create_conversation, execute};
 use std::sync::Arc;
 use support::{
-    TestFixture, collect_stream, expected_text, load_cassette, make_request, output_text, responses_turns,
-    unwrap_blocking,
+    TestFixture, collect_stream, expected_text, load_cassette, make_request, output_text, request_input_texts,
+    responses_turns, text_response, unwrap_blocking,
 };
 
 const DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/cassettes/text_only/conversation");
@@ -302,4 +302,54 @@ async fn test_multi_branch() {
     );
     assert_eq!(p5.status, "completed");
     assert_eq!(output_text(&p5), expected_text(t5));
+}
+
+#[tokio::test]
+async fn test_store_false_with_conversation_id_hydrates_but_does_not_persist() {
+    let fixture = TestFixture::new_with_responses(vec![
+        text_response("stored answer"),
+        text_response("stateless answer"),
+        text_response("final answer"),
+    ])
+    .await;
+    let ctx = &fixture.exec_ctx;
+    let conv_id = create_conversation(ctx).await.expect("create conv").conversation_id;
+
+    let p1 = unwrap_blocking(
+        execute(
+            make_request("seed", true, false, None, Some(conv_id.clone())),
+            Arc::clone(ctx),
+        )
+        .await
+        .expect("stored turn"),
+    );
+    assert_eq!(output_text(&p1), "stored answer");
+
+    let p2 = unwrap_blocking(
+        execute(
+            make_request("follow up", false, false, None, Some(conv_id.clone())),
+            Arc::clone(ctx),
+        )
+        .await
+        .expect("store=false follow-up"),
+    );
+    assert_eq!(output_text(&p2), "stateless answer");
+
+    let p3 = unwrap_blocking(
+        execute(make_request("third", true, false, None, Some(conv_id)), Arc::clone(ctx))
+            .await
+            .expect("stored third turn"),
+    );
+    assert_eq!(output_text(&p3), "final answer");
+
+    let requests = fixture.request_bodies().await;
+    assert_eq!(requests.len(), 3);
+    assert_eq!(
+        request_input_texts(&requests[1]),
+        vec!["seed", "stored answer", "follow up"]
+    );
+    assert_eq!(
+        request_input_texts(&requests[2]),
+        vec!["seed", "stored answer", "third"]
+    );
 }

--- a/crates/agentic-core/tests/stateful_responses_integration.rs
+++ b/crates/agentic-core/tests/stateful_responses_integration.rs
@@ -7,7 +7,10 @@ mod support;
 
 use agentic_core::executor::execute;
 use std::sync::Arc;
-use support::{TestFixture, collect_stream, expected_text, load_cassette, make_request, output_text, unwrap_blocking};
+use support::{
+    TestFixture, collect_stream, expected_text, load_cassette, make_request, output_text, request_input_texts,
+    text_response, unwrap_blocking,
+};
 
 const DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/cassettes/text_only/responses");
 
@@ -161,4 +164,105 @@ async fn test_store_disabled_not_reusable_as_previous_response_id() {
 
     // Assert — executor errors at rehydrate, before calling the LLM
     assert!(result.is_err(), "expected error for unstored previous_response_id");
+}
+
+#[tokio::test]
+async fn test_previous_response_id_rehydrates_full_checkpoint_history() {
+    let fixture = TestFixture::new_with_responses(vec![
+        text_response("first answer"),
+        text_response("second answer"),
+        text_response("third answer"),
+    ])
+    .await;
+
+    let p1 = unwrap_blocking(
+        execute(
+            make_request("turn 1", true, false, None, None),
+            Arc::clone(&fixture.exec_ctx),
+        )
+        .await
+        .expect("t1"),
+    );
+    let p2 = unwrap_blocking(
+        execute(
+            make_request("turn 2", true, false, Some(p1.id.clone()), None),
+            Arc::clone(&fixture.exec_ctx),
+        )
+        .await
+        .expect("t2"),
+    );
+    let p3 = unwrap_blocking(
+        execute(
+            make_request("turn 3", true, false, Some(p2.id), None),
+            Arc::clone(&fixture.exec_ctx),
+        )
+        .await
+        .expect("t3"),
+    );
+
+    assert_eq!(output_text(&p3), "third answer");
+    let requests = fixture.request_bodies().await;
+    assert_eq!(requests.len(), 3);
+    assert_eq!(
+        request_input_texts(&requests[2]),
+        vec!["turn 1", "first answer", "turn 2", "second answer", "turn 3"]
+    );
+}
+
+#[tokio::test]
+async fn test_store_false_with_previous_response_id_hydrates_but_does_not_persist() {
+    let fixture =
+        TestFixture::new_with_responses(vec![text_response("stored answer"), text_response("stateless answer")]).await;
+
+    let p1 = unwrap_blocking(
+        execute(
+            make_request("seed", true, false, None, None),
+            Arc::clone(&fixture.exec_ctx),
+        )
+        .await
+        .expect("stored turn"),
+    );
+    let p2 = unwrap_blocking(
+        execute(
+            make_request("follow up", false, false, Some(p1.id), None),
+            Arc::clone(&fixture.exec_ctx),
+        )
+        .await
+        .expect("store=false follow-up"),
+    );
+
+    assert_eq!(output_text(&p2), "stateless answer");
+    let requests = fixture.request_bodies().await;
+    assert_eq!(requests.len(), 2);
+    assert_eq!(
+        request_input_texts(&requests[1]),
+        vec!["seed", "stored answer", "follow up"]
+    );
+
+    let result = execute(
+        make_request("should not find stateless response", true, false, Some(p2.id), None),
+        Arc::clone(&fixture.exec_ctx),
+    )
+    .await;
+    assert!(result.is_err(), "store=false response should not be persisted");
+}
+
+#[tokio::test]
+async fn test_conversation_id_and_previous_response_id_are_rejected_together() {
+    let fixture = TestFixture::new_with_responses(vec![]).await;
+
+    let result = execute(
+        make_request(
+            "ambiguous",
+            true,
+            false,
+            Some("resp_ambiguous".to_string()),
+            Some("conv_ambiguous".to_string()),
+        ),
+        Arc::clone(&fixture.exec_ctx),
+    )
+    .await;
+
+    assert!(result.is_err(), "expected ambiguous state IDs to be rejected");
+    assert!(fixture.request_bodies().await.is_empty());
 }

--- a/crates/agentic-core/tests/storage_integration.rs
+++ b/crates/agentic-core/tests/storage_integration.rs
@@ -150,6 +150,10 @@ async fn test_response_store_with_previous_response() {
     let response = store.get("resp_2").await.expect("get failed");
 
     assert_eq!(response.previous_response_id, Some("resp_1".to_string()));
+    assert_eq!(response.history_item_ids.len(), 2);
+
+    let rehydrated = store.rehydrate("resp_2").await.expect("rehydrate failed");
+    assert_eq!(rehydrated.len(), 2);
 }
 
 // Edge case tests

--- a/crates/agentic-core/tests/support/mod.rs
+++ b/crates/agentic-core/tests/support/mod.rs
@@ -16,6 +16,7 @@ use axum::routing::post;
 use either::Either;
 use futures::StreamExt;
 use serde::Deserialize;
+use serde_json::Value;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
@@ -117,11 +118,16 @@ pub fn expected_text(turn: &Turn) -> String {
 pub struct MockServer {
     url: String,
     handle: JoinHandle<()>,
+    requests: Arc<Mutex<Vec<Value>>>,
 }
 
 impl MockServer {
     pub fn url(&self) -> &str {
         &self.url
+    }
+
+    pub async fn request_bodies(&self) -> Vec<Value> {
+        self.requests.lock().await.clone()
     }
 }
 
@@ -183,14 +189,20 @@ impl MockServer {
         let url = format!("http://{addr}");
         // Store as VecDeque for O(1) pop_front.
         let queue: Arc<Mutex<VecDeque<MockResponse>>> = Arc::new(Mutex::new(VecDeque::from(responses)));
+        let requests: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let requests_for_route = Arc::clone(&requests);
 
         let handle = tokio::spawn(async move {
             let app = Router::new()
                 .route(
                     "/v1/responses",
-                    post(move |_body: axum::body::Bytes| {
+                    post(move |body: axum::body::Bytes| {
                         let queue = Arc::clone(&queue);
+                        let requests = Arc::clone(&requests_for_route);
                         async move {
+                            let request_body =
+                                serde_json::from_slice::<Value>(&body).expect("request body should be valid JSON");
+                            requests.lock().await.push(request_body);
                             let mut q = queue.lock().await;
                             let resp = q.pop_front().expect("mock queue exhausted — check test setup");
                             build_response(resp)
@@ -207,7 +219,7 @@ impl MockServer {
             axum::serve(listener, app).await.ok();
         });
 
-        Self { url, handle }
+        Self { url, handle, requests }
     }
 }
 
@@ -226,7 +238,7 @@ pub async fn setup_pool() -> Arc<DbPool> {
 pub struct TestFixture {
     pub exec_ctx: Arc<ExecutionContext>,
     // Kept for its Drop impl — aborts the mock server when the test ends.
-    _server: MockServer,
+    server: MockServer,
 }
 
 impl TestFixture {
@@ -255,10 +267,80 @@ impl TestFixture {
             None,
         ));
 
-        Self {
-            exec_ctx,
-            _server: server,
-        }
+        Self { exec_ctx, server }
+    }
+
+    pub async fn new_with_responses(responses: Vec<MockResponse>) -> Self {
+        let server = MockServer::start_deque(responses).await;
+
+        let pool = setup_pool().await;
+        let conv_handler = ConversationHandler::new(ConversationStore::new(Arc::clone(&pool)));
+        let resp_handler = ResponseHandler::new(ResponseStore::new(Arc::clone(&pool)));
+        let client = Arc::new(reqwest::Client::new());
+        let exec_ctx = Arc::new(ExecutionContext::new(
+            conv_handler,
+            resp_handler,
+            client,
+            server.url().to_string(),
+            None,
+        ));
+
+        Self { exec_ctx, server }
+    }
+
+    pub async fn request_bodies(&self) -> Vec<Value> {
+        self.server.request_bodies().await
+    }
+}
+
+pub fn text_response(text: &str) -> MockResponse {
+    let id_suffix = text.replace(' ', "_");
+    MockResponse::Json(
+        serde_json::json!({
+            "id": format!("resp_upstream_{id_suffix}"),
+            "object": "response",
+            "created_at": 0,
+            "model": "test-model",
+            "status": "completed",
+            "output": [{
+                "id": format!("msg_upstream_{id_suffix}"),
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{
+                    "type": "output_text",
+                    "text": text,
+                    "annotations": []
+                }]
+            }],
+            "usage": null,
+            "incomplete_details": null,
+            "error": null,
+            "previous_response_id": null,
+            "conversation_id": null,
+            "instructions": null
+        })
+        .to_string(),
+    )
+}
+
+pub fn request_input_texts(body: &Value) -> Vec<String> {
+    match &body["input"] {
+        Value::String(text) => vec![text.clone()],
+        Value::Array(items) => items
+            .iter()
+            .filter_map(|item| match &item["content"] {
+                Value::String(text) => Some(text.clone()),
+                Value::Array(parts) => Some(
+                    parts
+                        .iter()
+                        .filter_map(|part| part["text"].as_str())
+                        .collect::<String>(),
+                ),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
     }
 }
 


### PR DESCRIPTION
## Summary
- Materialize ADR-02 response checkpoints by carrying prior history item IDs forward.
- Hydrate previous responses/conversations even when the new turn uses `store=false`, while keeping `store=false` turns unpersisted.
- Reject requests that provide both `conversation_id` and `previous_response_id`, and assert hydrated upstream request bodies in stateful tests.

## Test Plan
- `cargo test -p agentic-core`
- `cargo clippy -p agentic-core --all-targets -- -D warnings`