### PR TITLE
fix: `agentic-core` concurrency in db layer include benchmarks.

### DIFF
--- a/crates/agentic-core/benches/benches.rs
+++ b/crates/agentic-core/benches/benches.rs
@@ -1,6 +1,11 @@
 mod executor_throughput;
+mod storage_concurrent;
 mod storage_crud;
 
 use criterion::criterion_main;
 
-criterion_main!(storage_crud::storage_benches, executor_throughput::executor_benches);
+criterion_main!(
+    storage_crud::storage_benches,
+    storage_concurrent::storage_concurrent_benches,
+    executor_throughput::executor_benches
+);

--- a/crates/agentic-core/benches/storage_concurrent.rs
+++ b/crates/agentic-core/benches/storage_concurrent.rs
@@ -1,0 +1,421 @@
+//! Concurrent storage benchmarks for [`ConversationStore`] and [`ResponseStore`].
+//!
+//! Each benchmark group spawns N tasks simultaneously to measure throughput and
+//! contention under concurrent load.
+//!
+//! | Group                                        | What it measures                                     |
+//! |----------------------------------------------|------------------------------------------------------|
+//! | `concurrent_conversation_persist`            | N writers to the **same** conversation (seq contention) |
+//! | `concurrent_conversation_persist_independent`| N writers each to their **own** conversation         |
+//! | `concurrent_conversation_rehydrate`          | N readers of the **same** conversation               |
+//! | `concurrent_conversation_rehydrate_independent` | N readers each on their **own** conversation      |
+//! | `concurrent_response_persist`               | N independent response writes in parallel            |
+//! | `concurrent_response_rehydrate`             | N readers of the **same** response                  |
+//!
+//! # Configuring concurrency levels
+//!
+//! Set `BENCH_CONCURRENCY` to a comma-separated list of integers before running.
+//! Defaults to `2,4,8,16` when unset.
+//!
+//! ```bash
+//! # Run with default concurrency levels (2, 4, 8, 16)
+//! cargo bench --bench storage_concurrent
+//!
+//! # Run with custom concurrency levels
+//! BENCH_CONCURRENCY=2,4,8,16,32 cargo bench --bench storage_concurrent
+//!
+//! # Run a single group
+//! cargo bench --bench storage_concurrent -- concurrent_conversation_persist
+//! ```
+
+use std::sync::Arc;
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group};
+use tokio::runtime::Runtime;
+
+use agentic_core::storage::{ConversationStore, InOutItem, ResponseMetadata, ResponseStore, create_pool_with_schema};
+use agentic_core::types::io::{InputItem, InputMessage, InputMessageContent, OutputItem, OutputMessage};
+
+static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Parse `BENCH_CONCURRENCY` env var as a comma-separated list of integers.
+/// Falls back to `[2, 4, 8, 16]` when unset or unparseable.
+///
+/// Example: `BENCH_CONCURRENCY=1,2,4,8,16,32 cargo bench`
+fn concurrency_levels() -> Vec<usize> {
+    std::env::var("BENCH_CONCURRENCY")
+        .ok()
+        .and_then(|val| {
+            let levels: Vec<usize> = val.split(',').filter_map(|s| s.trim().parse().ok()).collect();
+            if levels.is_empty() { None } else { Some(levels) }
+        })
+        .unwrap_or_else(|| vec![2, 4, 8, 16])
+}
+
+fn next_id() -> String {
+    let count = COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    format!("bench_id_{count}")
+}
+
+fn make_items() -> Vec<InOutItem> {
+    let input = InputItem::Message(InputMessage {
+        role: "user".to_string(),
+        content: InputMessageContent::Text("Test message".to_string()),
+    });
+    vec![
+        InOutItem::Input(input.clone()),
+        InOutItem::Output(OutputItem::Message(OutputMessage::new("msg_123", "completed"))),
+        InOutItem::Input(input),
+    ]
+}
+
+fn make_metadata() -> ResponseMetadata {
+    ResponseMetadata::default()
+}
+
+fn bench_concurrent_conversation_persist(c: &mut Criterion, store: &ConversationStore) {
+    let store = Arc::new(store.clone());
+    let mut group = c.benchmark_group("concurrent_conversation_persist");
+
+    for concurrency in concurrency_levels() {
+        group.throughput(Throughput::Elements(concurrency as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(concurrency),
+            &concurrency,
+            |b, &concurrency| {
+                b.to_async(Runtime::new().unwrap()).iter_batched(
+                    || {
+                        let store = store.clone();
+                        async move { store.create().await.expect("create conversation").conversation_id }
+                    },
+                    |setup| {
+                        let store = store.clone();
+                        async move {
+                            let conversation_id = setup.await;
+                            let handles: Vec<_> = (0..concurrency)
+                                .map(|_| {
+                                    let store = store.clone();
+                                    let cid = conversation_id.clone();
+                                    tokio::spawn(async move {
+                                        store
+                                            .persist(
+                                                &cid,
+                                                &next_id(),
+                                                None,
+                                                black_box(make_items()),
+                                                &black_box(make_metadata()),
+                                            )
+                                            .await
+                                            .expect("concurrent conversation persist failed");
+                                    })
+                                })
+                                .collect();
+                            for h in handles {
+                                h.await.expect("task panicked");
+                            }
+                        }
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_concurrent_conversation_rehydrate(c: &mut Criterion, store: &ConversationStore) {
+    let store = Arc::new(store.clone());
+    let rt = Runtime::new().unwrap();
+
+    let conversation_id = rt.block_on(async {
+        let conv = store.create().await.expect("create conversation");
+        store
+            .persist(&conv.conversation_id, &next_id(), None, make_items(), &make_metadata())
+            .await
+            .expect("setup persist");
+        conv.conversation_id
+    });
+
+    let mut group = c.benchmark_group("concurrent_conversation_rehydrate");
+
+    for concurrency in concurrency_levels() {
+        group.throughput(Throughput::Elements(concurrency as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(concurrency),
+            &concurrency,
+            |b, &concurrency| {
+                b.to_async(Runtime::new().unwrap()).iter_batched(
+                    || conversation_id.clone(),
+                    |cid| {
+                        let store = store.clone();
+                        async move {
+                            let handles: Vec<_> = (0..concurrency)
+                                .map(|_| {
+                                    let store = store.clone();
+                                    let id = cid.clone();
+                                    tokio::spawn(async move {
+                                        store
+                                            .rehydrate(&black_box(id))
+                                            .await
+                                            .expect("concurrent rehydrate failed")
+                                    })
+                                })
+                                .collect();
+                            for h in handles {
+                                h.await.expect("task panicked");
+                            }
+                        }
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_concurrent_conversation_persist_independent(c: &mut Criterion, store: &ConversationStore) {
+    let store = Arc::new(store.clone());
+    let mut group = c.benchmark_group("concurrent_conversation_persist_independent");
+
+    for concurrency in concurrency_levels() {
+        group.throughput(Throughput::Elements(concurrency as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(concurrency),
+            &concurrency,
+            |b, &concurrency| {
+                b.to_async(Runtime::new().unwrap()).iter_batched(
+                    || {
+                        let store = store.clone();
+                        async move {
+                            let mut ids = Vec::with_capacity(concurrency);
+                            for _ in 0..concurrency {
+                                ids.push(store.create().await.expect("create conversation").conversation_id);
+                            }
+                            ids
+                        }
+                    },
+                    |setup| {
+                        let store = store.clone();
+                        async move {
+                            let conversation_ids = setup.await;
+                            let handles: Vec<_> = conversation_ids
+                                .into_iter()
+                                .map(|cid| {
+                                    let store = store.clone();
+                                    tokio::spawn(async move {
+                                        store
+                                            .persist(
+                                                &cid,
+                                                &next_id(),
+                                                None,
+                                                black_box(make_items()),
+                                                &black_box(make_metadata()),
+                                            )
+                                            .await
+                                            .expect("independent conversation persist failed");
+                                    })
+                                })
+                                .collect();
+                            for h in handles {
+                                h.await.expect("task panicked");
+                            }
+                        }
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_concurrent_conversation_rehydrate_independent(c: &mut Criterion, store: &ConversationStore) {
+    let store = Arc::new(store.clone());
+    let rt = Runtime::new().unwrap();
+
+    let max_concurrency = concurrency_levels().into_iter().max().unwrap_or(16);
+    let conversation_ids: Vec<String> = rt.block_on(async {
+        let mut ids = Vec::with_capacity(max_concurrency);
+        for _ in 0..max_concurrency {
+            let conv = store.create().await.expect("create conversation");
+            store
+                .persist(&conv.conversation_id, &next_id(), None, make_items(), &make_metadata())
+                .await
+                .expect("setup persist");
+            ids.push(conv.conversation_id);
+        }
+        ids
+    });
+
+    let mut group = c.benchmark_group("concurrent_conversation_rehydrate_independent");
+
+    for concurrency in concurrency_levels() {
+        group.throughput(Throughput::Elements(concurrency as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(concurrency),
+            &concurrency,
+            |b, &concurrency| {
+                b.to_async(Runtime::new().unwrap()).iter_batched(
+                    || conversation_ids[..concurrency].to_vec(),
+                    |ids| {
+                        let store = store.clone();
+                        async move {
+                            let handles: Vec<_> = ids
+                                .into_iter()
+                                .map(|id| {
+                                    let store = store.clone();
+                                    tokio::spawn(async move {
+                                        store
+                                            .rehydrate(&black_box(id))
+                                            .await
+                                            .expect("independent rehydrate failed")
+                                    })
+                                })
+                                .collect();
+                            for h in handles {
+                                h.await.expect("task panicked");
+                            }
+                        }
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_concurrent_response_persist(c: &mut Criterion, store: &ResponseStore) {
+    let store = Arc::new(store.clone());
+    let mut group = c.benchmark_group("concurrent_response_persist");
+
+    for concurrency in concurrency_levels() {
+        group.throughput(Throughput::Elements(concurrency as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(concurrency),
+            &concurrency,
+            |b, &concurrency| {
+                b.to_async(Runtime::new().unwrap()).iter_batched(
+                    || (0..concurrency).map(|_| next_id()).collect::<Vec<_>>(),
+                    |response_ids| {
+                        let store = store.clone();
+                        async move {
+                            let handles: Vec<_> = response_ids
+                                .into_iter()
+                                .map(|response_id| {
+                                    let store = store.clone();
+                                    tokio::spawn(async move {
+                                        store
+                                            .persist(
+                                                &response_id,
+                                                None,
+                                                black_box(make_items()),
+                                                &black_box(make_metadata()),
+                                            )
+                                            .await
+                                            .expect("concurrent response persist failed");
+                                    })
+                                })
+                                .collect();
+                            for h in handles {
+                                h.await.expect("task panicked");
+                            }
+                        }
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_concurrent_response_rehydrate(c: &mut Criterion, store: &ResponseStore) {
+    let store = Arc::new(store.clone());
+    let rt = Runtime::new().unwrap();
+
+    let response_id = rt.block_on(async {
+        let id = next_id();
+        store
+            .persist(&id, None, make_items(), &make_metadata())
+            .await
+            .expect("setup persist");
+        id
+    });
+
+    let mut group = c.benchmark_group("concurrent_response_rehydrate");
+
+    for concurrency in concurrency_levels() {
+        group.throughput(Throughput::Elements(concurrency as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(concurrency),
+            &concurrency,
+            |b, &concurrency| {
+                b.to_async(Runtime::new().unwrap()).iter_batched(
+                    || response_id.clone(),
+                    |rid| {
+                        let store = store.clone();
+                        async move {
+                            let handles: Vec<_> = (0..concurrency)
+                                .map(|_| {
+                                    let store = store.clone();
+                                    let id = rid.clone();
+                                    tokio::spawn(async move {
+                                        store
+                                            .rehydrate(&black_box(id))
+                                            .await
+                                            .expect("concurrent rehydrate failed")
+                                    })
+                                })
+                                .collect();
+                            for h in handles {
+                                h.await.expect("task panicked");
+                            }
+                        }
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn init_benches(c: &mut Criterion) {
+    COUNTER.store(0, std::sync::atomic::Ordering::SeqCst);
+
+    let rt = Runtime::new().unwrap();
+    let pool = rt.block_on(async {
+        create_pool_with_schema(None)
+            .await
+            .expect("failed to create pool with schema")
+    });
+
+    let conversation_store = ConversationStore::new(pool.clone());
+    let response_store = ResponseStore::new(pool.clone());
+
+    bench_concurrent_conversation_persist(c, &conversation_store);
+    bench_concurrent_conversation_persist_independent(c, &conversation_store);
+    bench_concurrent_conversation_rehydrate(c, &conversation_store);
+    bench_concurrent_conversation_rehydrate_independent(c, &conversation_store);
+    bench_concurrent_response_persist(c, &response_store);
+    bench_concurrent_response_rehydrate(c, &response_store);
+
+    rt.block_on(async {
+        sqlx::query("DELETE FROM items").execute(pool.as_ref()).await.ok();
+        sqlx::query("DELETE FROM responses").execute(pool.as_ref()).await.ok();
+        sqlx::query("DELETE FROM conversations")
+            .execute(pool.as_ref())
+            .await
+            .ok();
+    });
+}
+
+criterion_group!(storage_concurrent_benches, init_benches);

--- a/crates/agentic-core/src/storage/conversation.rs
+++ b/crates/agentic-core/src/storage/conversation.rs
@@ -99,9 +99,6 @@ impl ConversationStore {
         metadata: &ResponseMetadata,
     ) -> StoreResult<()> {
         let pool = self.pool()?;
-        let seq_start = item::conversation_item_count(pool, conversation_id)
-            .await?
-            .ok_or_else(|| StorageError::not_found("Conversation", conversation_id))?;
 
         let mut item_ids: Vec<String> = Vec::new();
         let mut items_: Vec<(String, String)> = Vec::new();
@@ -113,6 +110,10 @@ impl ConversationStore {
         }
 
         let mut tx = pool.begin().await?;
+
+        let seq_start = item::conversation_item_count(&mut tx, conversation_id)
+            .await?
+            .ok_or_else(|| StorageError::not_found("Conversation", conversation_id))?;
 
         item::create_in_tx(&mut tx, items_, Some(conversation_id), Some(seq_start)).await?;
 

--- a/crates/agentic-core/src/storage/models/item.rs
+++ b/crates/agentic-core/src/storage/models/item.rs
@@ -118,14 +118,17 @@ pub async fn get_items_by_conversation(pool: &DbPool, conversation_id: &str) -> 
         .await
 }
 
-/// Get next sequence number for items in a conversation.
+/// Get next sequence number for items in a conversation, within a transaction.
+///
+/// Reading inside the transaction ensures concurrent writers serialize on the same
+/// connection and cannot both claim the same sequence range.
 ///
 /// # Errors
 /// Returns `DbResult::Err` if the database query fails.
-pub async fn conversation_item_count(pool: &DbPool, conversation_id: &str) -> DbResult<Option<i64>> {
+pub async fn conversation_item_count(tx: &mut DbTransaction<'_>, conversation_id: &str) -> DbResult<Option<i64>> {
     let max_seq: Option<i64> = sqlx::query_scalar("SELECT MAX(seq) FROM items WHERE conversation_id = ?")
         .bind(conversation_id)
-        .fetch_optional(pool)
+        .fetch_optional(&mut **tx)
         .await?
         .flatten();
 

--- a/crates/agentic-core/src/storage/pool.rs
+++ b/crates/agentic-core/src/storage/pool.rs
@@ -60,9 +60,14 @@ pub async fn create_pool(db_url: Option<&str>) -> DbResult<Arc<DbPool>> {
     // Prepare URL with database-specific parameters
     let url = prepare_db_url(db_url);
 
-    // Create connection pool with 10 max connections
-    // This is a conservative default - tune based on your workload
-    let pool = AnyPoolOptions::new().max_connections(10).connect(&url).await?;
+    // SQLite only allows one writer at a time; a single connection in the pool
+    // serializes writes at the pool level (queue).
+    // For other databases, 10 connections is a conservative default.
+    let max_connections = if url.starts_with("sqlite") { 1 } else { 10 };
+    let pool = AnyPoolOptions::new()
+        .max_connections(max_connections)
+        .connect(&url)
+        .await?;
 
     // Wrap in Arc for thread-safe sharing across async tasks
     Ok(Arc::new(pool))

--- a/crates/agentic-core/tests/storage_integration.rs
+++ b/crates/agentic-core/tests/storage_integration.rs
@@ -258,7 +258,7 @@ async fn test_response_store_chaining_respects_foreign_key() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_conversation_concurrent_turns() {
     let pool = setup_pool().await;
     let store = ConversationStore::new(pool.clone());


### PR DESCRIPTION
# Summary

Fixes a sequence-number race in `ConversationStore::persist` mentioned in https://github.com/vllm-project/agentic-api/issues/53 and adds concurrent storage benchmarks to `agentic-core`. 
**Race fix (`storage/conversation.rs` + `storage/models/item.rs`):**

`conversation_item_count` previously ran outside the transaction, so two simultaneous requests with the same `conversation_id` could both snapshot the same `MAX(seq)` and overwrite each other's items. The fix moves the count read inside the transaction so the DB serializes the snapshot and the second writer always sees the first writer's committed seq.

**SQLite pool fix (`storage/pool.rs`):**

SQLite only supports one writer at a time. Setting `max_connections(1)` for SQLite pools serializes writes at the pool-queue level. Postgres/MySQL keep `max_connections(10)`.

**New benchmarks (`benches/storage_concurrent.rs`):**

| Group | What it measures |
|---|---|
| `concurrent_conversation_persist` | N writers to the **same** `conversation_id` |
| `concurrent_conversation_persist_independent` | N writers each to their own `conversation_id` |
| `concurrent_conversation_rehydrate` | N readers of the **same** `conversation_id` |
| `concurrent_conversation_rehydrate_independent` | N readers each on their own `conversation_id` |
| `concurrent_response_persist` | N writers each to their own `response_id` |
| `concurrent_response_rehydrate` | N readers of the **same** `response_id` |

Concurrency levels default to `[2, 4, 8, 16]`, configurable via `BENCH_CONCURRENCY=2,4,8,16,32`.

## Test Plan

`test_conversation_concurrent_turns` (existing, now fixed): two tasks persist to the same conversation concurrently; asserts both succeed and the rehydrated item count is correct. Runs on a `multi_thread` tokio runtime with `worker_threads = 2`.

```bash
cargo test -p agentic-core
cargo bench --bench benches -- concurrent_
BENCH_CONCURRENCY=2,4,8,16 cargo bench -p agentic-core --bench benches -- concurrent_
```

All 152 tests pass across the workspace.

## Benchmark Results

> SQLite · `sample-size=100` · concurrency 2-16

### `concurrent_conversation_persist` (same `conversation_id`)

| N | Median | Throughput |
|:-:|-------:|----------:|
| 2  | 56.6 ms | 35.3 elem/s |
| 4  | 200 ms  | 20.0 elem/s |
| 8  | 163 ms  | 49.1 elem/s |
| 16 | 569 ms  | 28.1 elem/s |

### `concurrent_conversation_persist_independent` (N distinct conversations)

| N | Median | Throughput |
|:-:|-------:|----------:|
| 2  | 70.7 ms | 28.3 elem/s |
| 4  | 229 ms  | 17.5 elem/s |
| 8  | 507 ms  | 15.8 elem/s |
| 16 | 756 ms  | 21.2 elem/s |

### `concurrent_conversation_rehydrate` (same `conversation_id`)

| N | Median | Throughput |
|:-:|-------:|----------:|
| 2  | 305 µs | 6.6 Kelem/s |
| 4  | 624 µs | 6.4 Kelem/s |
| 8  | 1.30 ms | 6.2 Kelem/s |
| 16 | 2.74 ms | 5.8 Kelem/s |

### `concurrent_conversation_rehydrate_independent`

| N | Median | Throughput |
|:-:|-------:|----------:|
| 2  | 299 µs | 6.7 Kelem/s |
| 4  | 610 µs | 6.6 Kelem/s |
| 8  | 1.33 ms | 6.0 Kelem/s |
| 16 | 2.71 ms | 5.9 Kelem/s |

### `concurrent_response_persist` (independent response IDs)

| N | Median | Throughput |
|:-:|-------:|----------:|
| 2  | 35.8 ms | 55.8 elem/s |
| 4  | 176 ms  | 22.7 elem/s |
| 8  | 163 ms  | 48.9 elem/s |
| 16 | 372 ms  | 43.0 elem/s |

### `concurrent_response_rehydrate` (same `response_id`)

| N | Median | Throughput |
|:-:|-------:|----------:|
| 2  | 591 µs | 3.4 Kelem/s |
| 4  | 1.19 ms | 3.4 Kelem/s |
| 8  | 2.50 ms | 3.2 Kelem/s |
| 16 | 4.81 ms | 3.3 Kelem/s |

### Analysis

**Reads scale linearly with N.** Both rehydrate groups show near-constant throughput (~6 Kelem/s for conversations, ~3.3 Kelem/s for responses) across all concurrency levels, confirming reads do not contend on SQLite's single-connection pool.

**Writes show high variance at N>=4.** The large confidence intervals on persist groups (especially `independent/16`: 557 ms-1.01 s) reflect SQLite pool-queue serialization cost accumulating as N grows. This is expected on SQLite; numbers will improve on Postgres where writers do not serialize.

**Same-target vs independent write throughput is comparable on SQLite** because the pool already serializes all writers through one connection. The distinction matters on Postgres where independent writes can proceed in parallel but same-`conversation_id` writes must still serialize to maintain seq ordering.

> **Note:** Concurrent write correctness has only been validated on SQLite. Postgres testing is out of scope for this PR. A follow-up should run `test_conversation_concurrent_turns` and the `concurrent_conversation_persist` benchmark groups against a real Postgres instance to verify the transaction fix holds under true parallel writers.