### PR TITLE
feat: support reasoning output items

### DIFF
--- a/crates/agentic-core/src/events/normalize.rs
+++ b/crates/agentic-core/src/events/normalize.rs
@@ -49,6 +49,10 @@ fn classify_event_type(type_str: &str) -> SSEEventType {
         "response.content_part.done" => SSEEventType::ContentPartDone,
         "response.function_call_arguments.delta" => SSEEventType::FunctionCallArgumentsDelta,
         "response.function_call_arguments.done" => SSEEventType::FunctionCallArgumentsDone,
+        "response.reasoning_text.delta" => SSEEventType::ReasoningTextDelta,
+        "response.reasoning_text.done" => SSEEventType::ReasoningTextDone,
+        "response.reasoning_part.added" => SSEEventType::ReasoningPartAdded,
+        "response.reasoning_part.done" => SSEEventType::ReasoningPartDone,
         "response.reasoning_summary_text.delta" => SSEEventType::ReasoningSummaryTextDelta,
         "response.reasoning_summary_text.done" => SSEEventType::ReasoningSummaryTextDone,
         "response.file_search_call.searching" => SSEEventType::FileSearchCallSearching,
@@ -77,11 +81,13 @@ fn extract_payload(event_type: SSEEventType, json: &Value) -> EventPayload {
         SSEEventType::FunctionCallArgumentsDelta => extract_fn_call_args_delta(json),
         SSEEventType::FunctionCallArgumentsDone => extract_fn_call_args_done(json),
 
-        SSEEventType::ReasoningSummaryTextDelta => extract_reasoning_delta(json),
-        SSEEventType::ReasoningSummaryTextDone => extract_reasoning_done(json),
+        SSEEventType::ReasoningTextDelta | SSEEventType::ReasoningSummaryTextDelta => extract_reasoning_delta(json),
+        SSEEventType::ReasoningTextDone | SSEEventType::ReasoningSummaryTextDone => extract_reasoning_done(json),
 
         SSEEventType::ContentPartAdded
         | SSEEventType::ContentPartDone
+        | SSEEventType::ReasoningPartAdded
+        | SSEEventType::ReasoningPartDone
         | SSEEventType::FileSearchCallSearching
         | SSEEventType::FileSearchCallCompleted
         | SSEEventType::WebSearchCallSearching

--- a/crates/agentic-core/src/events/types.rs
+++ b/crates/agentic-core/src/events/types.rs
@@ -29,6 +29,10 @@ pub enum SSEEventType {
     FunctionCallArgumentsDone,
 
     // Reasoning
+    ReasoningTextDelta,
+    ReasoningTextDone,
+    ReasoningPartAdded,
+    ReasoningPartDone,
     ReasoningSummaryTextDelta,
     ReasoningSummaryTextDone,
 

--- a/crates/agentic-core/src/executor/accumulator.rs
+++ b/crates/agentic-core/src/executor/accumulator.rs
@@ -15,7 +15,9 @@ use futures::{Stream, StreamExt};
 use crate::events::{EventFrame, EventPayload, SSEEventType, normalize_sse_line};
 use crate::executor::error::{ExecutorError, ExecutorResult};
 use crate::types::event::{MessageStatus, ResponseStatus};
-use crate::types::io::{OutputItem, OutputMessage, OutputTextContent, ResponseUsage};
+use crate::types::io::{
+    OutputItem, OutputMessage, OutputTextContent, ReasoningOutput, ReasoningTextContent, ResponseUsage,
+};
 use crate::types::request_response::{IncompleteDetails, ResponsePayload};
 use crate::utils::common::{deserialize_from_str, deserialize_from_value_opt};
 use crate::utils::uuid7_str;
@@ -32,6 +34,9 @@ pub struct ResponseAccumulator {
     // In-flight message state — owned here so process_sse_line takes only &mut self.
     current_message: Option<OutputMessage>,
     accumulated_text: String,
+    // In-flight reasoning state.
+    current_reasoning: Option<ReasoningOutput>,
+    accumulated_reasoning_text: String,
 }
 
 impl ResponseAccumulator {
@@ -47,6 +52,8 @@ impl ResponseAccumulator {
             incomplete_details: None,
             current_message: None,
             accumulated_text: String::new(),
+            current_reasoning: None,
+            accumulated_reasoning_text: String::new(),
         }
     }
 
@@ -90,6 +97,8 @@ impl ResponseAccumulator {
             incomplete_details: None,
             current_message: None,
             accumulated_text: String::new(),
+            current_reasoning: None,
+            accumulated_reasoning_text: String::new(),
         })
     }
 
@@ -141,6 +150,7 @@ impl ResponseAccumulator {
         for line in rx {
             acc.process_sse_line(&line);
         }
+        acc.finalize_current_reasoning();
         acc.finalize_current_message();
         if acc.status == ResponseStatus::InProgress {
             acc.status = ResponseStatus::Completed;
@@ -159,8 +169,22 @@ impl ResponseAccumulator {
         for line in lines {
             acc.process_sse_line(&line);
         }
+        acc.finalize_current_reasoning();
         acc.finalize_current_message();
         acc
+    }
+
+    /// Closes the in-flight reasoning item, pushing it to `output` with accumulated text.
+    fn finalize_current_reasoning(&mut self) {
+        if let Some(mut reasoning) = self.current_reasoning.take() {
+            if !self.accumulated_reasoning_text.is_empty() {
+                reasoning
+                    .content
+                    .push(ReasoningTextContent::new(&self.accumulated_reasoning_text));
+            }
+            self.output.push(OutputItem::Reasoning(reasoning));
+        }
+        self.accumulated_reasoning_text.clear();
     }
 
     /// Closes the in-flight message, pushing it to `output` with accumulated text.
@@ -194,19 +218,46 @@ impl ResponseAccumulator {
             (SSEEventType::ResponseCreated, EventPayload::Response { id, .. }) if !id.is_empty() => {
                 self.response_id.clone_from(id);
             }
-            (SSEEventType::OutputItemAdded, EventPayload::OutputItemAdded { item_id, .. }) => {
-                self.finalize_current_message();
-                let id = if item_id.is_empty() {
-                    uuid7_str("msg_")
+            (SSEEventType::OutputItemAdded, EventPayload::OutputItemAdded { item_id, item_type, .. }) => {
+                let item_id = if item_id.is_empty() {
+                    let prefix = if item_type == "reasoning" { "rs_" } else { "msg_" };
+                    uuid7_str(prefix)
                 } else {
                     item_id.clone()
                 };
-                self.current_message = Some(OutputMessage::new(id, MessageStatus::InProgress.as_str()));
+                if item_type == "reasoning" {
+                    self.finalize_current_message();
+                    self.finalize_current_reasoning();
+                    self.current_reasoning = Some(ReasoningOutput::new(item_id));
+                } else {
+                    self.finalize_current_reasoning();
+                    self.finalize_current_message();
+                    self.current_message = Some(OutputMessage::new(item_id, MessageStatus::InProgress.as_str()));
+                }
+            }
+            (SSEEventType::ReasoningTextDelta, EventPayload::ReasoningDelta { delta, .. }) => {
+                self.accumulated_reasoning_text.push_str(delta);
+            }
+            (SSEEventType::ReasoningTextDone, EventPayload::ReasoningDone { text, .. }) => {
+                // Text done finalizes the content but the reasoning item stays
+                // open until the next output_item.added or response.done.
+                if let Some(reasoning) = self.current_reasoning.as_mut() {
+                    let text = if text.is_empty() {
+                        std::mem::take(&mut self.accumulated_reasoning_text)
+                    } else {
+                        text.clone()
+                    };
+                    self.accumulated_reasoning_text.clear();
+                    if !text.is_empty() {
+                        reasoning.content.push(ReasoningTextContent::new(text));
+                    }
+                }
             }
             (SSEEventType::OutputTextDelta, EventPayload::TextDelta { delta, .. }) => {
                 self.accumulated_text.push_str(delta);
             }
             (SSEEventType::ResponseCompleted, EventPayload::Response { usage, .. }) => {
+                self.finalize_current_reasoning();
                 self.finalize_current_message();
                 self.status = ResponseStatus::Completed;
                 if let Some(u) = usage {
@@ -464,5 +515,108 @@ mod tests {
         assert_eq!(acc.response_id, "resp_1");
         assert_eq!(acc.status, ResponseStatus::InProgress);
         assert!(acc.output.is_empty());
+    }
+
+    #[test]
+    fn test_accumulator_reasoning_and_message_from_sse() {
+        let lines = vec![
+            r#"data: {"type":"response.created","response":{"id":"resp_abc"}}"#.to_string(),
+            r#"data: {"type":"response.output_item.added","item":{"id":"rs_1","type":"reasoning","summary":[]}}"#
+                .to_string(),
+            r#"data: {"type":"response.reasoning_text.delta","delta":"Let me "}"#.to_string(),
+            r#"data: {"type":"response.reasoning_text.delta","delta":"think."}"#.to_string(),
+            r#"data: {"type":"response.reasoning_text.done","text":"Let me think."}"#.to_string(),
+            r#"data: {"type":"response.output_item.added","item":{"id":"msg_1","type":"message"}}"#.to_string(),
+            r#"data: {"type":"response.output_text.delta","delta":"Hello"}"#.to_string(),
+            r#"data: {"type":"response.done","response":{"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15}}}"#.to_string(),
+        ];
+
+        let acc = ResponseAccumulator::from_sse_lines(lines, None);
+        assert_eq!(acc.status, ResponseStatus::Completed);
+        assert_eq!(acc.output.len(), 2);
+
+        if let OutputItem::Reasoning(r) = &acc.output[0] {
+            assert_eq!(r.id, "rs_1");
+            assert_eq!(r.content.len(), 1);
+            assert_eq!(r.content[0].text, "Let me think.");
+        } else {
+            panic!("expected OutputItem::Reasoning, got {:?}", acc.output[0]);
+        }
+
+        if let OutputItem::Message(msg) = &acc.output[1] {
+            assert_eq!(msg.id, "msg_1");
+            assert_eq!(msg.content[0].text, "Hello");
+        } else {
+            panic!("expected OutputItem::Message");
+        }
+    }
+
+    #[test]
+    fn test_accumulator_message_then_reasoning_preserves_order() {
+        let lines = vec![
+            r#"data: {"type":"response.created","response":{"id":"resp_abc"}}"#.to_string(),
+            r#"data: {"type":"response.output_item.added","item":{"id":"msg_1","type":"message"}}"#.to_string(),
+            r#"data: {"type":"response.output_text.delta","delta":"Hello"}"#.to_string(),
+            r#"data: {"type":"response.output_item.added","item":{"id":"rs_1","type":"reasoning","summary":[]}}"#
+                .to_string(),
+            r#"data: {"type":"response.reasoning_text.done","text":"thinking..."}"#.to_string(),
+            r#"data: {"type":"response.done","response":{"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15}}}"#
+                .to_string(),
+        ];
+
+        let acc = ResponseAccumulator::from_sse_lines(lines, None);
+        assert_eq!(acc.output.len(), 2);
+        assert!(matches!(acc.output[0], OutputItem::Message(_)));
+        assert!(matches!(acc.output[1], OutputItem::Reasoning(_)));
+    }
+
+    #[test]
+    fn test_accumulator_reasoning_done_without_delta_uses_text() {
+        let lines = vec![
+            r#"data: {"type":"response.output_item.added","item":{"id":"rs_1","type":"reasoning","summary":[]}}"#
+                .to_string(),
+            r#"data: {"type":"response.reasoning_text.done","text":"done only"}"#.to_string(),
+            r#"data: {"type":"response.done","response":{"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}"#
+                .to_string(),
+        ];
+
+        let acc = ResponseAccumulator::from_sse_lines(lines, None);
+        if let OutputItem::Reasoning(reasoning) = &acc.output[0] {
+            assert_eq!(reasoning.content.len(), 1);
+            assert_eq!(reasoning.content[0].text, "done only");
+        } else {
+            panic!("expected reasoning output");
+        }
+    }
+
+    #[test]
+    fn test_accumulator_reasoning_from_json() {
+        let body = serde_json::json!({
+            "id": "resp_xyz",
+            "status": "completed",
+            "output": [
+                {
+                    "id": "rs_1",
+                    "type": "reasoning",
+                    "summary": [],
+                    "content": [{"text": "thinking...", "type": "reasoning_text"}],
+                    "encrypted_content": null,
+                    "status": null
+                },
+                {
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "answer", "annotations": []}]
+                }
+            ],
+            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+        });
+
+        let acc = ResponseAccumulator::from_json(&body.to_string(), None).unwrap();
+        assert_eq!(acc.output.len(), 2);
+        assert!(matches!(acc.output[0], OutputItem::Reasoning(_)));
+        assert!(matches!(acc.output[1], OutputItem::Message(_)));
     }
 }

--- a/crates/agentic-core/src/lib.rs
+++ b/crates/agentic-core/src/lib.rs
@@ -16,7 +16,7 @@ pub use storage::{
 pub use types::{
     FunctionTool, FunctionToolCall, FunctionToolResultMessage, IncompleteDetails, InputContent, InputImageContent,
     InputItem, InputMessage, InputMessageContent, InputTextContent, InputTokenDetails, OutputItem, OutputMessage,
-    OutputTextContent, OutputTokenDetails, RequestPayload, ResponsePayload, ResponseUsage, ResponsesInput,
-    ResponsesTool, ToolChoice, UpstreamRequest,
+    OutputTextContent, OutputTokenDetails, ReasoningOutput, ReasoningTextContent, RequestPayload, ResponsePayload,
+    ResponseUsage, ResponsesInput, ResponsesTool, ToolChoice, UpstreamRequest,
 };
 pub use utils::{utcnow_str, uuid7_str};

--- a/crates/agentic-core/src/storage/models/item.rs
+++ b/crates/agentic-core/src/storage/models/item.rs
@@ -3,7 +3,7 @@
 use tracing::warn;
 
 use super::super::pool::{DbPool, DbResult, DbTransaction};
-use super::super::types::item::InOutItem;
+use super::super::types::item::{InOutItem, ItemKind, STORED_ITEM_KIND_KEY};
 use crate::types::io::{InputItem, OutputItem};
 use crate::utils::common::{deserialize_from_str_opt, utcnow_str};
 
@@ -46,6 +46,21 @@ impl Item {
     /// Deserialize data column as either `InputItem` or `OutputItem`.
     #[must_use]
     pub fn as_inout(&self) -> Option<InOutItem> {
+        if let Some(kind) = self.stored_item_kind() {
+            match kind {
+                ItemKind::Input => {
+                    if let Some(input) = self.as_input().filter(|input| !matches!(input, InputItem::Unknown)) {
+                        return Some(InOutItem::Input(input));
+                    }
+                }
+                ItemKind::Output => {
+                    if let Some(output) = self.as_output().filter(|output| !matches!(output, OutputItem::Unknown)) {
+                        return Some(InOutItem::Output(output));
+                    }
+                }
+            }
+        }
+
         match (self.as_input(), self.as_output()) {
             (Some(input), _) if !matches!(input, InputItem::Unknown) => Some(InOutItem::Input(input)),
             (_, Some(output)) if !matches!(output, OutputItem::Unknown) => Some(InOutItem::Output(output)),
@@ -54,6 +69,11 @@ impl Item {
                 None
             }
         }
+    }
+
+    fn stored_item_kind(&self) -> Option<ItemKind> {
+        let value = deserialize_from_str_opt::<serde_json::Value>(&self.data)?;
+        ItemKind::from_stored_str(value.get(STORED_ITEM_KIND_KEY)?.as_str()?)
     }
 }
 
@@ -138,6 +158,7 @@ pub async fn conversation_item_count(tx: &mut DbTransaction<'_>, conversation_id
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::io::{OutputItem, ReasoningOutput, ReasoningTextContent};
 
     #[test]
     fn test_item_basic() {
@@ -166,5 +187,24 @@ mod tests {
 
         assert!(item.conversation_id.is_none());
         assert!(item.seq.is_none());
+    }
+
+    #[test]
+    fn test_as_inout_uses_stored_kind_for_reasoning_output() {
+        let mut reasoning = ReasoningOutput::new("rs_1");
+        reasoning.content.push(ReasoningTextContent::new("thinking..."));
+        let stored = InOutItem::Output(OutputItem::Reasoning(reasoning));
+        let item = Item {
+            id: "item_reasoning".to_string(),
+            data: String::try_from(&stored).expect("serialization failed"),
+            created_at: 1_704_067_200,
+            conversation_id: None,
+            seq: None,
+        };
+
+        assert!(matches!(
+            item.as_inout(),
+            Some(InOutItem::Output(OutputItem::Reasoning(_)))
+        ));
     }
 }

--- a/crates/agentic-core/src/storage/types/item.rs
+++ b/crates/agentic-core/src/storage/types/item.rs
@@ -3,17 +3,36 @@
 use std::convert::TryFrom;
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::storage::StorageError;
 use crate::types::io::{InputItem, OutputItem};
-use crate::utils::common::serialize_to_string;
+
+pub(crate) const STORED_ITEM_KIND_KEY: &str = "_agentic_item_kind";
 
 /// Item kind (input vs output) for storage and retrieval.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ItemKind {
     Input,
     Output,
+}
+
+impl ItemKind {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Input => "input",
+            Self::Output => "output",
+        }
+    }
+
+    pub(crate) fn from_stored_str(value: &str) -> Option<Self> {
+        match value {
+            "input" => Some(Self::Input),
+            "output" => Some(Self::Output),
+            _ => None,
+        }
+    }
 }
 
 /// Union type for conversation items (input or output).
@@ -39,10 +58,25 @@ impl TryFrom<&InOutItem> for String {
     type Error = StorageError;
 
     fn try_from(item: &InOutItem) -> Result<Self, Self::Error> {
-        match item {
-            InOutItem::Input(input) => serialize_to_string(input).map_err(StorageError::Serialization),
-            InOutItem::Output(output) => serialize_to_string(output).map_err(StorageError::Serialization),
+        let (mut value, kind) = match item {
+            InOutItem::Input(input) => (
+                serde_json::to_value(input).map_err(StorageError::Serialization)?,
+                ItemKind::Input,
+            ),
+            InOutItem::Output(output) => (
+                serde_json::to_value(output).map_err(StorageError::Serialization)?,
+                ItemKind::Output,
+            ),
+        };
+
+        if let Some(obj) = value.as_object_mut() {
+            obj.insert(
+                STORED_ITEM_KIND_KEY.to_string(),
+                Value::String(kind.as_str().to_string()),
+            );
         }
+
+        serde_json::to_string(&value).map_err(StorageError::Serialization)
     }
 }
 
@@ -54,10 +88,8 @@ impl InOutItem {
             .into_iter()
             .filter_map(|i| match i {
                 InOutItem::Input(item) => Some(item),
-                InOutItem::Output(OutputItem::Message(msg)) => {
-                    // Embed history OutputMessage as an input item so the model sees prior turns.
-                    Some(InputItem::Message(msg.into()))
-                }
+                InOutItem::Output(OutputItem::Message(msg)) => Some(InputItem::Message(msg.into())),
+                InOutItem::Output(OutputItem::Reasoning(r)) => Some(InputItem::Reasoning(r)),
                 InOutItem::Output(OutputItem::FunctionCall(_) | OutputItem::Unknown) => None,
             })
             .collect()
@@ -67,7 +99,10 @@ impl InOutItem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::io::{InputContent, InputMessage, InputMessageContent, OutputMessage, OutputTextContent};
+    use crate::types::io::{
+        InputContent, InputMessage, InputMessageContent, OutputMessage, OutputTextContent, ReasoningOutput,
+        ReasoningTextContent,
+    };
 
     #[test]
     fn test_inout_item_from_input() {
@@ -94,6 +129,8 @@ mod tests {
         });
         let item = InOutItem::Input(input);
         let json = String::try_from(&item).expect("serialization failed");
+        assert!(json.contains(STORED_ITEM_KIND_KEY));
+        assert!(json.contains("input"));
         assert!(json.contains("user"));
         assert!(json.contains("test"));
     }
@@ -133,7 +170,25 @@ mod tests {
                     InputMessageContent::Text(_) => panic!("expected parts content"),
                 }
             }
-            InputItem::FunctionCallOutput(_) | InputItem::Unknown => panic!("expected message"),
+            _ => panic!("expected message"),
+        }
+    }
+
+    #[test]
+    fn test_into_input_items_includes_reasoning() {
+        let mut reasoning = ReasoningOutput::new("rs_1");
+        reasoning.content.push(ReasoningTextContent::new("thinking..."));
+        let items = vec![
+            InOutItem::Output(OutputItem::Reasoning(reasoning)),
+            InOutItem::Output(OutputItem::Message(OutputMessage::new("msg_1", "completed"))),
+        ];
+
+        let inputs = InOutItem::into_input_items(items);
+        assert_eq!(inputs.len(), 2);
+        assert!(matches!(inputs[0], InputItem::Reasoning(_)));
+        if let InputItem::Reasoning(r) = &inputs[0] {
+            assert_eq!(r.id, "rs_1");
+            assert_eq!(r.content[0].text, "thinking...");
         }
     }
 

--- a/crates/agentic-core/src/types/io.rs
+++ b/crates/agentic-core/src/types/io.rs
@@ -51,6 +51,8 @@ pub enum InputItem {
     Message(InputMessage),
     #[serde(rename = "function_call_output")]
     FunctionCallOutput(FunctionToolResultMessage),
+    #[serde(rename = "reasoning")]
+    Reasoning(ReasoningOutput),
     #[serde(other)]
     Unknown,
 }
@@ -123,12 +125,53 @@ pub struct FunctionToolCall {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReasoningTextContent {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub text: String,
+}
+
+impl ReasoningTextContent {
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            type_: "reasoning_text".into(),
+            text: text.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReasoningOutput {
+    pub id: String,
+    #[serde(default)]
+    pub content: Vec<ReasoningTextContent>,
+    #[serde(default)]
+    pub summary: Vec<Value>,
+    pub encrypted_content: Option<Value>,
+    pub status: Option<String>,
+}
+
+impl ReasoningOutput {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            content: vec![],
+            summary: vec![],
+            encrypted_content: None,
+            status: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum OutputItem {
     #[serde(rename = "message")]
     Message(OutputMessage),
     #[serde(rename = "function_call")]
     FunctionCall(FunctionToolCall),
+    #[serde(rename = "reasoning")]
+    Reasoning(ReasoningOutput),
     #[serde(other)]
     Unknown,
 }
@@ -210,4 +253,66 @@ pub(crate) fn resolve_tool_choice(
 pub enum ResponsesInput {
     Text(String),
     Items(Vec<InputItem>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reasoning_output_round_trips_through_serde() {
+        let json = serde_json::json!({
+            "id": "rs_abc",
+            "type": "reasoning",
+            "summary": [],
+            "content": [{"text": "Let me think...", "type": "reasoning_text"}],
+            "encrypted_content": null,
+            "status": null
+        });
+        let item: OutputItem = serde_json::from_value(json).unwrap();
+        assert!(matches!(item, OutputItem::Reasoning(_)));
+        if let OutputItem::Reasoning(r) = &item {
+            assert_eq!(r.id, "rs_abc");
+            assert_eq!(r.content.len(), 1);
+            assert_eq!(r.content[0].text, "Let me think...");
+        }
+        let serialized = serde_json::to_value(&item).unwrap();
+        assert_eq!(serialized["type"], "reasoning");
+        assert_eq!(serialized["id"], "rs_abc");
+    }
+
+    #[test]
+    fn reasoning_input_round_trips_through_serde() {
+        let reasoning = ReasoningOutput::new("rs_1");
+        let item = InputItem::Reasoning(reasoning);
+        let json = serde_json::to_value(&item).unwrap();
+        assert_eq!(json["type"], "reasoning");
+        let back: InputItem = serde_json::from_value(json).unwrap();
+        assert!(matches!(back, InputItem::Reasoning(_)));
+    }
+
+    #[test]
+    fn vllm_reasoning_response_deserializes() {
+        let vllm_output = serde_json::json!([
+            {
+                "id": "rs_bb637a529f72b88d",
+                "summary": [],
+                "type": "reasoning",
+                "content": [{"text": "2+2 is 4.", "type": "reasoning_text"}],
+                "encrypted_content": null,
+                "status": null
+            },
+            {
+                "id": "msg_bb68f033f2ed1725",
+                "content": [{"annotations": [], "text": "2+2 equals 4.", "type": "output_text"}],
+                "role": "assistant",
+                "status": "completed",
+                "type": "message"
+            }
+        ]);
+        let items: Vec<OutputItem> = serde_json::from_value(vllm_output).unwrap();
+        assert_eq!(items.len(), 2);
+        assert!(matches!(items[0], OutputItem::Reasoning(_)));
+        assert!(matches!(items[1], OutputItem::Message(_)));
+    }
 }

--- a/crates/agentic-core/src/types/mod.rs
+++ b/crates/agentic-core/src/types/mod.rs
@@ -5,6 +5,7 @@ pub mod request_response;
 pub use io::{
     FunctionTool, FunctionToolCall, FunctionToolResultMessage, InputContent, InputImageContent, InputItem,
     InputMessage, InputMessageContent, InputTextContent, InputTokenDetails, OutputItem, OutputMessage,
-    OutputTextContent, OutputTokenDetails, ResponseUsage, ResponsesInput, ResponsesTool, ToolChoice,
+    OutputTextContent, OutputTokenDetails, ReasoningOutput, ReasoningTextContent, ResponseUsage, ResponsesInput,
+    ResponsesTool, ToolChoice,
 };
 pub use request_response::{IncompleteDetails, RequestPayload, ResponsePayload, UpstreamRequest};

--- a/crates/agentic-core/tests/event_normalizer_test.rs
+++ b/crates/agentic-core/tests/event_normalizer_test.rs
@@ -241,6 +241,48 @@ fn test_reasoning_done_reads_text_not_delta() {
 }
 
 #[test]
+fn test_reasoning_text_delta() {
+    let line = r#"data: {"type":"response.reasoning_text.delta","delta":"The user asks","item_id":"rs_1","output_index":0,"content_index":0,"sequence_number":4}"#;
+    let frame = normalize_sse_line(line).unwrap();
+    assert_eq!(frame.event_type, SSEEventType::ReasoningTextDelta);
+    if let EventPayload::ReasoningDelta { delta, item_id } = &frame.payload {
+        assert_eq!(delta, "The user asks");
+        assert_eq!(item_id, "rs_1");
+    } else {
+        panic!("expected ReasoningDelta payload");
+    }
+}
+
+#[test]
+fn test_reasoning_text_done() {
+    let line = r#"data: {"type":"response.reasoning_text.done","text":"The user asks about math.","item_id":"rs_1","output_index":0,"content_index":0,"sequence_number":10}"#;
+    let frame = normalize_sse_line(line).unwrap();
+    assert_eq!(frame.event_type, SSEEventType::ReasoningTextDone);
+    if let EventPayload::ReasoningDone { text, item_id } = &frame.payload {
+        assert_eq!(text, "The user asks about math.");
+        assert_eq!(item_id, "rs_1");
+    } else {
+        panic!("expected ReasoningDone payload");
+    }
+}
+
+#[test]
+fn test_reasoning_part_added_classified() {
+    let line = r#"data: {"type":"response.reasoning_part.added","content_index":0,"item_id":"rs_1","output_index":0,"part":{"text":"","type":"reasoning_text"},"sequence_number":3}"#;
+    let frame = normalize_sse_line(line).unwrap();
+    assert_eq!(frame.event_type, SSEEventType::ReasoningPartAdded);
+    assert!(matches!(frame.payload, EventPayload::Raw(_)));
+}
+
+#[test]
+fn test_reasoning_part_done_classified() {
+    let line = r#"data: {"type":"response.reasoning_part.done","content_index":0,"item_id":"rs_1","output_index":0,"part":{"text":"thinking...","type":"reasoning_text"},"sequence_number":80}"#;
+    let frame = normalize_sse_line(line).unwrap();
+    assert_eq!(frame.event_type, SSEEventType::ReasoningPartDone);
+    assert!(matches!(frame.payload, EventPayload::Raw(_)));
+}
+
+#[test]
 fn test_response_failed() {
     let line = r#"data: {"type":"response.failed","response":{"id":"resp_err","status":"failed","usage":null},"sequence_number":2}"#;
     let frame = normalize_sse_line(line).unwrap();

--- a/crates/agentic-core/tests/support/mod.rs
+++ b/crates/agentic-core/tests/support/mod.rs
@@ -404,7 +404,7 @@ pub fn output_text(payload: &ResponsePayload) -> String {
         .iter()
         .filter_map(|item| match item {
             OutputItem::Message(msg) => Some(msg.content.iter().map(|c| c.text.as_str()).collect::<String>()),
-            OutputItem::FunctionCall(_) | OutputItem::Unknown => None,
+            OutputItem::FunctionCall(_) | OutputItem::Reasoning(_) | OutputItem::Unknown => None,
         })
         .collect::<String>()
 }


### PR DESCRIPTION
**Summary**
- Add typed reasoning input/output item support for vLLM Responses payloads.
- Accumulate streamed `response.reasoning_text.*` events into `reasoning` output items.
- Preserve reasoning items during stateful rehydration so follow-up requests sent through Agentic API keep the full vLLM Responses history.
- Add storage disambiguation for input vs output items that share the same wire shape.

**Context**
We found this while testing Agentic API against a local vLLM server through the Responses API. Models that emit reasoning return output like `{ "type": "reasoning", ... }` before the assistant message. The previous typed model did not represent those items, so they could be dropped or misclassified during parsing, streaming accumulation, and rehydration.

For stateful flows, this matters on the next request: Agentic API reconstructs the prior response history and forwards it to vLLM as `input`. vLLM expects the reasoning items, including their `content`, to be present in that reconstructed history. Without preserving them, follow-up requests can lose model reasoning context or fail compatibility with vLLM's Responses implementation.

Example captured from local vLLM at `http://10.0.0.99:8000/v1/responses` with `openai/gpt-oss-20b`:

```json
{
  "status": "completed",
  "output": [
    {
      "id": "rs_b4371fd8b4767c3f",
      "type": "reasoning",
      "status": null,
      "content": [
        {
          "type": "reasoning_text",
          "text": "The user asks: \"What is 2+2? Answer briefly.\" We can answer succinctly: \"4.\""
        }
      ]
    },
    {
      "id": "msg_944a5458f4b5be23",
      "type": "message",
      "status": "completed",
      "content": [
        {
          "type": "output_text",
          "text": "4.",
          "annotations": []
        }
      ]
    }
  ]
}
```

This PR makes reasoning items first-class in the core types, handles both non-streaming JSON and streaming SSE forms, and adds regression coverage for done-only reasoning text, message/reasoning item ordering, and storage round-tripping.

**Test Plan**
- `cargo fmt -- --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- Manually tested against local vLLM Responses API with reasoning output, including non-streaming, streaming, and stateful follow-up rehydration