### PR TITLE
chore: remove duplicate SSE event enum

### DIFF
--- a/crates/agentic-core/src/types/event.rs
+++ b/crates/agentic-core/src/types/event.rs
@@ -1,4 +1,4 @@
-//! Server-Sent Event (SSE) types and response status enums.
+//! Response and message status enums.
 
 use std::convert::Infallible;
 use std::str::FromStr;
@@ -83,81 +83,9 @@ impl FromStr for MessageStatus {
     }
 }
 
-/// Server-Sent Event types from LLM streaming responses.
-///
-/// Emitted by vLLM when `stream=true`. Each variant represents one step in the
-/// response generation process.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum SSEEventType {
-    /// Response object created; contains initial response metadata.
-    ResponseCreated,
-
-    /// Output item (message) added; marks the start of a new message.
-    ResponseOutputItemAdded,
-
-    /// Text delta; incremental token content added to the current message.
-    ResponseOutputTextDelta,
-
-    /// Response fully completed; no more events will follow.
-    ResponseDone,
-
-    /// Unknown or unhandled event type.
-    #[default]
-    Other,
-}
-
-impl FromStr for SSEEventType {
-    type Err = Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "response.created" => Self::ResponseCreated,
-            "response.output_item.added" => Self::ResponseOutputItemAdded,
-            "response.output_text.delta" => Self::ResponseOutputTextDelta,
-            // vLLM uses `response.done`; OpenAI uses `response.completed`.
-            "response.done" | "response.completed" => Self::ResponseDone,
-            _ => Self::Other,
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_sse_event_type_from_str_created() {
-        assert_eq!(
-            "response.created".parse::<SSEEventType>().unwrap(),
-            SSEEventType::ResponseCreated
-        );
-    }
-
-    #[test]
-    fn test_sse_event_type_from_str_delta() {
-        assert_eq!(
-            "response.output_text.delta".parse::<SSEEventType>().unwrap(),
-            SSEEventType::ResponseOutputTextDelta
-        );
-    }
-
-    #[test]
-    fn test_sse_event_type_from_str_done() {
-        assert_eq!(
-            "response.done".parse::<SSEEventType>().unwrap(),
-            SSEEventType::ResponseDone
-        );
-    }
-
-    #[test]
-    fn test_sse_event_type_from_str_unknown() {
-        assert_eq!("unknown.event".parse::<SSEEventType>().unwrap(), SSEEventType::Other);
-    }
-
-    #[test]
-    fn test_sse_event_type_from_str_empty() {
-        assert_eq!("".parse::<SSEEventType>().unwrap(), SSEEventType::Other);
-    }
 
     #[test]
     fn test_response_status_round_trip() {


### PR DESCRIPTION
**Summary**
- Remove the unused legacy `types::event::SSEEventType` enum and its local parser tests.
- Keep SSE event classification centralized in `agentic_core::events`, which is the canonical path used by the streaming accumulator and event normalizer.
- Update the `types::event` module doc comment so it only describes the remaining response and message status enums.

**Context**
- Follow-up to the review discussion in #57, where we agreed the remaining duplicate SSE enum should be cleaned up separately after reasoning output support landed.

**Test Plan**
- `cargo fmt -- --check`
- `cargo test -p agentic-core types::event::tests`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
