### PR TITLE
feat: benchmark proxy payload scaling

### DIFF
--- a/crates/agentic-server/benches/proxy_bench.rs
+++ b/crates/agentic-server/benches/proxy_bench.rs
@@ -1,4 +1,5 @@
 use std::convert::Infallible;
+use std::sync::Arc;
 
 use axum::body::Body;
 use axum::extract::Request;
@@ -6,7 +7,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Router, serve};
 use bytes::Bytes;
-use criterion::{Criterion, criterion_group};
+use criterion::{BenchmarkId, Criterion, criterion_group};
 use futures::stream;
 use http::StatusCode;
 use tokio::net::TcpListener;
@@ -18,7 +19,9 @@ use agentic_core::executor::{ConversationHandler, ExecutionContext, ResponseHand
 use agentic_core::proxy::ProxyState;
 use agentic_core::storage::{ConversationStore, ResponseStore};
 use agentic_server::app::{AppState, ServerConfig, build_router};
-use std::sync::Arc;
+
+const CONTENT_TYPE_JSON: &str = "application/json";
+const PAYLOAD_SIZES: [usize; 3] = [1024, 10 * 1024, 100 * 1024];
 
 fn bench_config(llm_url: &str) -> Config {
     Config {
@@ -58,7 +61,7 @@ async fn responses_handler(req: Request) -> Response {
     }
 
     let out = r#"{"id":"resp_bench","object":"response","status":"completed"}"#;
-    (StatusCode::OK, [("content-type", "application/json")], out).into_response()
+    (StatusCode::OK, [("content-type", CONTENT_TYPE_JSON)], out).into_response()
 }
 
 async fn spawn_llm() -> String {
@@ -102,6 +105,96 @@ async fn spawn_gateway(config: Config) -> String {
     format!("http://{addr}")
 }
 
+fn responses_url(base_url: &str) -> String {
+    format!("{base_url}/v1/responses")
+}
+
+fn request_body(prompt_bytes: usize, stream: bool) -> Bytes {
+    let prompt = "x".repeat(prompt_bytes);
+    let body = serde_json::json!({
+        "model": "bench-model",
+        "input": [{"role": "user", "content": prompt}],
+        "store": false,
+        "stream": stream
+    });
+    Bytes::from(serde_json::to_vec(&body).expect("benchmark request body serializes"))
+}
+
+async fn post_response(client: reqwest::Client, url: String, body: Bytes) -> usize {
+    let resp = client
+        .post(url)
+        .header("content-type", CONTENT_TYPE_JSON)
+        .body(body)
+        .send()
+        .await
+        .expect("benchmark request succeeds");
+
+    resp.bytes().await.expect("benchmark response body").len()
+}
+
+fn bench_single_request(c: &mut Criterion, rt: &Runtime, client: &reqwest::Client, llm_url: &str, gateway_url: &str) {
+    let non_stream_body = request_body(5, false);
+    let stream_body = request_body(5, true);
+
+    let mut group = c.benchmark_group("non_stream");
+
+    group.bench_function("direct", |b| {
+        let url = responses_url(llm_url);
+        let body = non_stream_body.clone();
+        b.to_async(rt)
+            .iter(|| post_response(client.clone(), url.clone(), body.clone()));
+    });
+
+    group.bench_function("proxied", |b| {
+        let url = responses_url(gateway_url);
+        let body = non_stream_body.clone();
+        b.to_async(rt)
+            .iter(|| post_response(client.clone(), url.clone(), body.clone()));
+    });
+
+    group.finish();
+
+    let mut group = c.benchmark_group("stream");
+
+    group.bench_function("direct", |b| {
+        let url = responses_url(llm_url);
+        let body = stream_body.clone();
+        b.to_async(rt)
+            .iter(|| post_response(client.clone(), url.clone(), body.clone()));
+    });
+
+    group.bench_function("proxied", |b| {
+        let url = responses_url(gateway_url);
+        let body = stream_body.clone();
+        b.to_async(rt)
+            .iter(|| post_response(client.clone(), url.clone(), body.clone()));
+    });
+
+    group.finish();
+}
+
+fn bench_body_size(c: &mut Criterion, rt: &Runtime, client: &reqwest::Client, llm_url: &str, gateway_url: &str) {
+    let mut group = c.benchmark_group("non_stream/body_size");
+
+    for size in PAYLOAD_SIZES {
+        group.bench_with_input(BenchmarkId::new("direct", size), &size, |b, &size| {
+            let url = responses_url(llm_url);
+            let body = request_body(size, false);
+            b.to_async(rt)
+                .iter(|| post_response(client.clone(), url.clone(), body.clone()));
+        });
+
+        group.bench_with_input(BenchmarkId::new("proxied", size), &size, |b, &size| {
+            let url = responses_url(gateway_url);
+            let body = request_body(size, false);
+            b.to_async(rt)
+                .iter(|| post_response(client.clone(), url.clone(), body.clone()));
+        });
+    }
+
+    group.finish();
+}
+
 fn proxy_benchmarks(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
 
@@ -114,79 +207,8 @@ fn proxy_benchmarks(c: &mut Criterion) {
 
     let client = reqwest::Client::new();
 
-    let non_stream_body = serde_json::json!({
-        "model": "bench-model",
-        "input": [{"role": "user", "content": "hello"}]
-    });
-    let stream_body = serde_json::json!({
-        "model": "bench-model",
-        "input": [{"role": "user", "content": "hello"}],
-        "stream": true
-    });
-
-    let mut group = c.benchmark_group("non_stream");
-
-    group.bench_function("direct", |b| {
-        let url = format!("{llm_url}/v1/responses");
-        let body = non_stream_body.clone();
-        b.to_async(&rt).iter(|| {
-            let client = client.clone();
-            let url = url.clone();
-            let body = body.clone();
-            async move {
-                let resp = client.post(&url).json(&body).send().await.unwrap();
-                resp.bytes().await.unwrap()
-            }
-        });
-    });
-
-    group.bench_function("proxied", |b| {
-        let url = format!("{gateway_url}/v1/responses");
-        let body = non_stream_body.clone();
-        b.to_async(&rt).iter(|| {
-            let client = client.clone();
-            let url = url.clone();
-            let body = body.clone();
-            async move {
-                let resp = client.post(&url).json(&body).send().await.unwrap();
-                resp.bytes().await.unwrap()
-            }
-        });
-    });
-
-    group.finish();
-
-    let mut group = c.benchmark_group("stream");
-
-    group.bench_function("direct", |b| {
-        let url = format!("{llm_url}/v1/responses");
-        let body = stream_body.clone();
-        b.to_async(&rt).iter(|| {
-            let client = client.clone();
-            let url = url.clone();
-            let body = body.clone();
-            async move {
-                let resp = client.post(&url).json(&body).send().await.unwrap();
-                resp.bytes().await.unwrap()
-            }
-        });
-    });
-
-    group.bench_function("proxied", |b| {
-        let url = format!("{gateway_url}/v1/responses");
-        let body = stream_body.clone();
-        b.to_async(&rt).iter(|| {
-            let client = client.clone();
-            let url = url.clone();
-            let body = body.clone();
-            async move {
-                let resp = client.post(&url).json(&body).send().await.unwrap();
-                resp.bytes().await.unwrap()
-            }
-        });
-    });
-
-    group.finish();
+    bench_single_request(c, &rt, &client, &llm_url, &gateway_url);
+    bench_body_size(c, &rt, &client, &llm_url, &gateway_url);
 }
 
 criterion_group!(proxy_benches, proxy_benchmarks);

--- a/crates/agentic-server/benches/proxy_bench.rs
+++ b/crates/agentic-server/benches/proxy_bench.rs
@@ -21,7 +21,7 @@ use agentic_core::storage::{ConversationStore, ResponseStore};
 use agentic_server::app::{AppState, ServerConfig, build_router};
 
 const CONTENT_TYPE_JSON: &str = "application/json";
-const PAYLOAD_SIZES: [usize; 3] = [1024, 10 * 1024, 100 * 1024];
+const PROMPT_SIZES: [usize; 3] = [1024, 10 * 1024, 100 * 1024];
 
 fn bench_config(llm_url: &str) -> Config {
     Config {
@@ -60,6 +60,7 @@ async fn responses_handler(req: Request) -> Response {
             .into_response();
     }
 
+    // Keep the mock response fixed so prompt-size runs isolate request upload overhead.
     let out = r#"{"id":"resp_bench","object":"response","status":"completed"}"#;
     (StatusCode::OK, [("content-type", CONTENT_TYPE_JSON)], out).into_response()
 }
@@ -173,23 +174,31 @@ fn bench_single_request(c: &mut Criterion, rt: &Runtime, client: &reqwest::Clien
     group.finish();
 }
 
-fn bench_body_size(c: &mut Criterion, rt: &Runtime, client: &reqwest::Client, llm_url: &str, gateway_url: &str) {
-    let mut group = c.benchmark_group("non_stream/body_size");
+fn bench_prompt_size(c: &mut Criterion, rt: &Runtime, client: &reqwest::Client, llm_url: &str, gateway_url: &str) {
+    let mut group = c.benchmark_group("non_stream/prompt_bytes");
 
-    for size in PAYLOAD_SIZES {
-        group.bench_with_input(BenchmarkId::new("direct", size), &size, |b, &size| {
-            let url = responses_url(llm_url);
-            let body = request_body(size, false);
-            b.to_async(rt)
-                .iter(|| post_response(client.clone(), url.clone(), body.clone()));
-        });
+    for prompt_bytes in PROMPT_SIZES {
+        group.bench_with_input(
+            BenchmarkId::new("direct", prompt_bytes),
+            &prompt_bytes,
+            |b, &prompt_bytes| {
+                let url = responses_url(llm_url);
+                let body = request_body(prompt_bytes, false);
+                b.to_async(rt)
+                    .iter(|| post_response(client.clone(), url.clone(), body.clone()));
+            },
+        );
 
-        group.bench_with_input(BenchmarkId::new("proxied", size), &size, |b, &size| {
-            let url = responses_url(gateway_url);
-            let body = request_body(size, false);
-            b.to_async(rt)
-                .iter(|| post_response(client.clone(), url.clone(), body.clone()));
-        });
+        group.bench_with_input(
+            BenchmarkId::new("proxied", prompt_bytes),
+            &prompt_bytes,
+            |b, &prompt_bytes| {
+                let url = responses_url(gateway_url);
+                let body = request_body(prompt_bytes, false);
+                b.to_async(rt)
+                    .iter(|| post_response(client.clone(), url.clone(), body.clone()));
+            },
+        );
     }
 
     group.finish();
@@ -208,7 +217,7 @@ fn proxy_benchmarks(c: &mut Criterion) {
     let client = reqwest::Client::new();
 
     bench_single_request(c, &rt, &client, &llm_url, &gateway_url);
-    bench_body_size(c, &rt, &client, &llm_url, &gateway_url);
+    bench_prompt_size(c, &rt, &client, &llm_url, &gateway_url);
 }
 
 criterion_group!(proxy_benches, proxy_benchmarks);

--- a/crates/agentic-server/tests/responses_test.rs
+++ b/crates/agentic-server/tests/responses_test.rs
@@ -1,12 +1,11 @@
 mod common;
 
-use std::sync::Arc;
-
 use axum::Router;
 use axum::body::Bytes;
 use axum::response::IntoResponse;
 use axum::routing::post;
 use http::StatusCode;
+use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 
@@ -131,6 +130,35 @@ async fn test_store_false_with_web_search_reaches_executor() {
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0]["tools"][0]["type"], "function");
     assert_eq!(requests[0]["tools"][0]["name"], "web_search");
+}
+
+#[tokio::test]
+async fn test_store_false_proxies_large_json_body_to_vllm() {
+    // Arrange
+    let (llm_url, requests, _h1) = spawn_mock_vllm_json_capture().await;
+    let (gw_url, _h2) = spawn_gateway(test_state(&test_config(&llm_url))).await;
+    let prompt = "x".repeat(100 * 1024);
+
+    // Act
+    let resp = reqwest::Client::new()
+        .post(format!("{gw_url}/v1/responses"))
+        .json(&serde_json::json!({
+            "model": "test",
+            "input": [{"type": "message", "role": "user", "content": prompt}],
+            "store": false,
+            "stream": false
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // Assert — the gateway keeps this below-limit request on the proxy path.
+    assert_eq!(resp.status(), 200);
+    let requests = requests.lock().await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0]["store"], false);
+    assert_eq!(requests[0]["stream"], false);
+    assert_eq!(requests[0]["input"][0]["content"].as_str().unwrap().len(), 100 * 1024);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Refs #32.

Extends the existing `agentic-server` proxy Criterion benchmark with Phase 1 coverage for proxy-overhead payload-size scaling:

- keeps the existing direct vs proxied non-streaming and streaming baselines
- sends explicit `store: false` request bodies so proxied cases exercise the proxy path
- adds non-streaming payload-size benchmarks for 1 KiB, 10 KiB, and 100 KiB prompts
- adds an integration test proving a below-limit 100 KiB `store: false` request reaches the mock vLLM on the proxy path with the expected request shape

The benchmark still uses the local mock LLM and local gateway, so it remains deterministic and does not require a live vLLM server.

Per review feedback, concurrency benchmarking is intentionally left out of this proxy-only benchmark and can be handled in `gateway_bench.rs` / database-backed gateway benchmarks.

## Benchmark Results

Run locally on this branch with:

```bash
cargo +stable bench -p agentic-server --bench benches -- 'non_stream/body_size'
```

| Prompt size | Direct median | Proxied median | Approx. overhead |
| --- | ---: | ---: | ---: |
| 1 KiB | 39.900 µs | 50.737 µs | +10.837 µs |
| 10 KiB | 44.493 µs | 53.605 µs | +9.112 µs |
| 100 KiB | 76.618 µs | 82.224 µs | +5.606 µs |

These numbers use the local mock upstream and should be treated as reference data for this benchmark harness, not production latency claims.

## Test Plan

- `cargo +stable fmt --all --check`
- `rtk test cargo +stable test -p agentic-server`
- `cargo +stable clippy -p agentic-server --all-targets -- -D warnings`
- `cargo +stable test -p agentic-server --benches --no-run`
- `cargo +stable bench -p agentic-server --bench benches -- 'non_stream/body_size'`