### PR TITLE
fix: tighten codex namespace invariants

### DIFF
--- a/crates/agentic-core/src/executor/engine.rs
+++ b/crates/agentic-core/src/executor/engine.rs
@@ -107,13 +107,10 @@ async fn run_until_gateway_tools_complete(
     stream_upstream: bool,
     stream_events: Option<&mpsc::UnboundedSender<String>>,
 ) -> ExecutorResult<(ResponsePayload, RequestContext)> {
-    let registry: ToolRegistry = ctx
-        .enriched_request
-        .tools
-        .as_ref()
-        .map_or_else(ToolRegistry::default, |tools| {
-            ToolRegistry::build_with_handlers(tools, |tool_type| exec_ctx.gateway_executors.get(tool_type))
-        });
+    let registry: ToolRegistry = match ctx.enriched_request.tools.as_ref() {
+        Some(tools) => ToolRegistry::build_with_handlers(tools, |tool_type| exec_ctx.gateway_executors.get(tool_type))?,
+        None => ToolRegistry::default(),
+    };
     let mut combined_output: Vec<crate::OutputItem> = Vec::new();
     let mut combined_usage: Option<ResponseUsage> = None;
 

--- a/crates/agentic-core/src/executor/upstream.rs
+++ b/crates/agentic-core/src/executor/upstream.rs
@@ -21,8 +21,8 @@ pub(super) async fn fetch_blocking_payload(
 ) -> ExecutorResult<ResponsePayload> {
     let url = exec_ctx.responses_url();
     // Non-streaming request: stream=false -> full JSON body -> from_json.
-    let upstream_json =
-        serialize_to_string(&ctx.enriched_request.to_upstream_request(false)).map_err(ExecutorError::JsonError)?;
+    let upstream_request = ctx.enriched_request.to_upstream_request(false)?;
+    let upstream_json = serialize_to_string(&upstream_request).map_err(ExecutorError::JsonError)?;
 
     let body = fetch_response_json(upstream_json, &url, &exec_ctx.client, auth).await?;
 
@@ -45,8 +45,8 @@ pub(super) async fn fetch_stream_payload(
     stream_events: Option<&mpsc::UnboundedSender<String>>,
 ) -> ExecutorResult<ResponsePayload> {
     let url = exec_ctx.responses_url();
-    let upstream_json =
-        serialize_to_string(&ctx.enriched_request.to_upstream_request(true)).map_err(ExecutorError::JsonError)?;
+    let upstream_request = ctx.enriched_request.to_upstream_request(true)?;
+    let upstream_json = serialize_to_string(&upstream_request).map_err(ExecutorError::JsonError)?;
     let mut line_stream = Box::pin(call_inference(
         upstream_json,
         url,

--- a/crates/agentic-core/src/tool/codex.rs
+++ b/crates/agentic-core/src/tool/codex.rs
@@ -65,8 +65,6 @@ impl NamespaceMap {
 struct NamespaceMapBuilder {
     top_level_names: HashSet<String>,
     map: NamespaceMap,
-    #[cfg(test)]
-    flat_name_collisions: usize,
 }
 
 impl NamespaceMapBuilder {
@@ -77,29 +75,44 @@ impl NamespaceMapBuilder {
         }
     }
 
-    fn namespace_has_flat_name_collision<'a>(
-        &self,
+    fn validate_and_record_flat_member(
+        &mut self,
         namespace_name: &str,
-        member_names: impl IntoIterator<Item = &'a str>,
-    ) -> bool {
-        member_names.into_iter().any(|member_name| {
-            self.top_level_names
-                .contains(&model_visible_namespace_member_name(namespace_name, member_name))
-        })
+        member_name: &str,
+    ) -> Result<String, ToolError> {
+        let flat_name = model_visible_namespace_member_name(namespace_name, member_name);
+        if self.top_level_names.contains(&flat_name) {
+            return Err(ToolError::Config(format!(
+                "codex namespace member {namespace_name}.{member_name} collides with top-level function {flat_name}"
+            )));
+        }
+        if let Some(existing) = self.map.calls.get(&flat_name) {
+            if existing.member.namespace != namespace_name || existing.member.name != member_name {
+                return Err(ToolError::Config(format!(
+                    "codex namespace member {namespace_name}.{member_name} collides with {}.{} at generated name {flat_name}",
+                    existing.member.namespace, existing.member.name
+                )));
+            }
+        }
+        Ok(self.record_flat_member_with_flat_name(namespace_name, member_name, flat_name))
     }
 
-    fn record_flat_member(&mut self, namespace_name: &str, member_name: &str) -> String {
-        let flat_name = model_visible_namespace_member_name(namespace_name, member_name);
+    fn record_flat_member_with_flat_name(
+        &mut self,
+        namespace_name: &str,
+        member_name: &str,
+        flat_name: String,
+    ) -> String {
         let member = NamespaceMemberName {
             namespace: namespace_name.to_string(),
             name: member_name.to_string(),
         };
         if let Some(existing) = self.map.calls.get(&flat_name) {
+            debug_assert!(
+                existing.member == member,
+                "namespace collisions must be validated before recording namespace members"
+            );
             if existing.member != member {
-                #[cfg(test)]
-                {
-                    self.flat_name_collisions += 1;
-                }
                 tracing::warn!(
                     upstream_name = %flat_name,
                     namespace = %namespace_name,
@@ -118,11 +131,6 @@ impl NamespaceMapBuilder {
         self.map.members.insert(member, flat_name.clone());
         self.map.calls.insert(flat_name.clone(), mapping);
         flat_name
-    }
-
-    #[cfg(test)]
-    fn flat_name_collision_count(&self) -> usize {
-        self.flat_name_collisions
     }
 
     fn finish(self) -> NamespaceMap {
@@ -148,20 +156,23 @@ impl CodexNamespaceHandler {
     /// [`super::registry::ToolRegistry::build_with_handlers`] can read each
     /// member's already-flat name directly, with no further namespace logic.
     ///
-    /// A namespace whose flat member names would collide with a declared
-    /// top-level tool name is left unrenamed (its members keep colliding
-    /// with each other under one upstream name, so it's dropped downstream
-    /// instead — see [`rename_namespace_members`]).
-    #[must_use]
-    pub fn resolve_namespace_members(&self, tools: &[ResponsesTool]) -> Vec<ResponsesTool> {
+    /// Request execution must handle the result so ambiguous declarations fail
+    /// instead of being normalized into an irreversible flat shape.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ToolError::Config`] when a generated namespace member name
+    /// collides with a top-level function tool or with another namespace
+    /// member.
+    pub fn resolve_namespace_members(&self, tools: &[ResponsesTool]) -> Result<Vec<ResponsesTool>, ToolError> {
         let mut builder = NamespaceMapBuilder::new(typed_top_level_tool_names(tools));
         tools
             .iter()
             .map(|tool| match tool {
                 ResponsesTool::Namespace(namespace) => {
-                    ResponsesTool::Namespace(rename_namespace_members(namespace, &mut builder))
+                    rename_namespace_members(namespace, &mut builder).map(ResponsesTool::Namespace)
                 }
-                other => other.clone(),
+                other => Ok(other.clone()),
             })
             .collect()
     }
@@ -169,9 +180,41 @@ impl CodexNamespaceHandler {
     /// Builds a [`NamespaceMap`] once from a request's declared tools, for
     /// reuse across every subsequent restore/rewrite call on that request —
     /// see [`NamespaceMap`]'s docs for why this matters.
-    #[must_use]
-    pub fn build_namespace_map(&self, tools: Option<&[ResponsesTool]>) -> Option<NamespaceMap> {
+    /// # Errors
+    ///
+    /// Returns [`ToolError::Config`] when a generated namespace member name
+    /// collides with a top-level function tool or with another namespace
+    /// member.
+    pub fn build_namespace_map(&self, tools: Option<&[ResponsesTool]>) -> Result<Option<NamespaceMap>, ToolError> {
         namespace_map_from_tools(tools)
+    }
+
+    /// Rejects namespace declarations that cannot be represented
+    /// unambiguously by the gateway-owned flat model-visible naming scheme.
+    ///
+    /// This must run before building the upstream request or request-scoped
+    /// registry. Otherwise the gateway could silently drop a namespace member
+    /// or restore a flat model call to the wrong public `{ namespace, name }`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ToolError::Config`] when a generated namespace member name
+    /// collides with a top-level function tool or with another namespace
+    /// member.
+    pub fn validate_namespace_collisions(&self, tools: Option<&[ResponsesTool]>) -> Result<(), ToolError> {
+        let Some(tools) = tools else {
+            return Ok(());
+        };
+        let mut builder = NamespaceMapBuilder::new(typed_top_level_tool_names(tools));
+        for tool in tools {
+            let ResponsesTool::Namespace(namespace) = tool else {
+                continue;
+            };
+            for member_name in typed_function_member_names(namespace) {
+                builder.validate_and_record_flat_member(&namespace.name, &member_name)?;
+            }
+        }
+        Ok(())
     }
 
     /// Resolves the request's `tool_choice` (defaulting to `ToolChoice::Auto`
@@ -243,53 +286,49 @@ impl ToolHandler for CodexNamespaceHandler {
     }
 }
 
-fn namespace_map_from_tools(tools: Option<&[ResponsesTool]>) -> Option<NamespaceMap> {
-    let tools = tools?;
+fn namespace_map_from_tools(tools: Option<&[ResponsesTool]>) -> Result<Option<NamespaceMap>, ToolError> {
+    let Some(tools) = tools else {
+        return Ok(None);
+    };
     let mut builder = NamespaceMapBuilder::new(typed_top_level_tool_names(tools));
     for tool in tools {
         if let ResponsesTool::Namespace(namespace) = tool {
-            let _ = rename_namespace_members(namespace, &mut builder);
+            let _ = rename_namespace_members(namespace, &mut builder)?;
         }
     }
-    Some(builder.finish())
+    Ok(Some(builder.finish()))
 }
 
 /// Returns `namespace` with its function members' names rewritten to their
 /// flat, model-visible form, recording each rename in `builder` along the
-/// way. On a flat-name collision with a declared top-level tool, members are
-/// left unrenamed (the namespace still has a non-empty `tools` list, so
-/// callers must not assume renaming always changes names).
+/// way.
+///
+/// # Errors
+///
+/// Returns [`ToolError::Config`] when a generated namespace member name
+/// collides with a top-level function tool or with another namespace member.
 fn rename_namespace_members(
     namespace: &CodexNamespaceToolParam,
     builder: &mut NamespaceMapBuilder,
-) -> CodexNamespaceToolParam {
+) -> Result<CodexNamespaceToolParam, ToolError> {
     let function_member_names = typed_function_member_names(namespace);
     if function_member_names.is_empty() {
         tracing::debug!(
             namespace = %namespace.name,
             "namespace tool has no function members to rename for upstream"
         );
-        return namespace.clone();
+        return Ok(namespace.clone());
     }
-    if builder.namespace_has_flat_name_collision(&namespace.name, function_member_names.iter().map(String::as_str)) {
-        tracing::debug!(
-            namespace = %namespace.name,
-            "leaving namespace tool members unrenamed because a top-level tool uses a generated name"
-        );
-        return namespace.clone();
-    }
-
     let tools = namespace
         .tools
         .iter()
         .map(|member| {
             let CodexNamespaceMember::Function(function) = member else {
-                return member.clone();
+                return Ok(member.clone());
             };
-            let flat_name_text = builder.record_flat_member(&namespace.name, function.name.as_str());
-            let Ok(flat_name) = NonEmptyToolName::try_from(flat_name_text.clone()) else {
-                return member.clone();
-            };
+            let flat_name_text = builder.validate_and_record_flat_member(&namespace.name, function.name.as_str())?;
+            let flat_name = NonEmptyToolName::try_from(flat_name_text.clone())
+                .expect("generated namespace member names include a non-empty prefix");
             tracing::debug!(
                 namespace = %namespace.name,
                 member = %function.name.as_str(),
@@ -298,14 +337,14 @@ fn rename_namespace_members(
             );
             let mut function = function.clone();
             function.name = flat_name;
-            CodexNamespaceMember::Function(function)
+            Ok(CodexNamespaceMember::Function(function))
         })
-        .collect();
+        .collect::<Result<Vec<_>, ToolError>>()?;
 
-    CodexNamespaceToolParam {
+    Ok(CodexNamespaceToolParam {
         tools,
         ..namespace.clone()
-    }
+    })
 }
 
 fn typed_top_level_tool_names(tools: &[ResponsesTool]) -> HashSet<String> {
@@ -360,16 +399,21 @@ fn rewrite_tool_choice_with_map(choice: &ToolChoice, map: &NamespaceMap) -> Tool
     };
     let mapping = namespace
         .as_deref()
-        .and_then(|namespace| map.mapping_for_member(namespace, name))
-        .or_else(|| namespace.is_none().then(|| map.mapping_for_call(name)).flatten());
+        .and_then(|namespace| map.mapping_for_member(namespace, name.as_str()))
+        .or_else(|| {
+            namespace
+                .is_none()
+                .then(|| map.mapping_for_call(name.as_str()))
+                .flatten()
+        });
     let Some(mapping) = mapping else {
         return choice.clone();
     };
+    let Ok(name) = NonEmptyToolName::try_from(mapping.upstream_name.clone()) else {
+        return choice.clone();
+    };
 
-    ToolChoice::Function {
-        namespace: None,
-        name: mapping.upstream_name.clone(),
-    }
+    ToolChoice::Function { namespace: None, name }
 }
 
 fn restore_response_value_with_map(value: &mut Value, map: &NamespaceMap) -> bool {
@@ -453,20 +497,24 @@ mod tests {
         .unwrap();
         let choice = ToolChoice::Function {
             namespace: None,
-            name: "run".to_string(),
+            name: NonEmptyToolName::try_from("run").unwrap(),
         };
 
-        let map = CodexNamespaceHandler.build_namespace_map(Some(&tools));
+        let map = CodexNamespaceHandler
+            .build_namespace_map(Some(&tools))
+            .expect("valid namespace map");
         let rewritten = CodexNamespaceHandler.resolve_tool_choice(map.as_ref(), Some(&choice));
 
         assert_eq!(
             rewritten,
             ToolChoice::Function {
                 namespace: None,
-                name: "run".to_string()
+                name: NonEmptyToolName::try_from("run").unwrap()
             }
         );
-        let resolved = CodexNamespaceHandler.resolve_namespace_members(&tools);
+        let resolved = CodexNamespaceHandler
+            .resolve_namespace_members(&tools)
+            .expect("valid namespace members");
         assert!(matches!(
             resolved.as_slice(),
             [ResponsesTool::Namespace(namespace)]
@@ -496,20 +544,22 @@ mod tests {
         }))
         .unwrap();
 
-        let map = CodexNamespaceHandler.build_namespace_map(Some(&tools));
+        let map = CodexNamespaceHandler
+            .build_namespace_map(Some(&tools))
+            .expect("valid namespace map");
         let rewritten = CodexNamespaceHandler.resolve_tool_choice(map.as_ref(), Some(&choice));
 
         assert_eq!(
             rewritten,
             ToolChoice::Function {
                 namespace: None,
-                name: "agentic_ns__mcp__git__run".to_string()
+                name: NonEmptyToolName::try_from("agentic_ns__mcp__git__run").unwrap()
             }
         );
     }
 
     #[test]
-    fn flatten_tools_does_not_generate_colliding_namespace_member_name() {
+    fn validate_namespace_collisions_rejects_top_level_flat_name_collision() {
         let tools: Vec<ResponsesTool> = serde_json::from_value(serde_json::json!([
             {"type": "function", "name": "agentic_ns__mcp__shell__run"},
             {
@@ -520,29 +570,64 @@ mod tests {
         ]))
         .unwrap();
 
-        let resolved = CodexNamespaceHandler.resolve_namespace_members(&tools);
-        let flat_function_count = resolved
-            .iter()
-            .filter(|tool| matches!(tool, ResponsesTool::Function(function) if function.name.as_str() == "agentic_ns__mcp__shell__run"))
-            .count();
-        let ResponsesTool::Namespace(namespace) = &resolved[1] else {
-            panic!("expected namespace tool");
-        };
+        let err = CodexNamespaceHandler
+            .validate_namespace_collisions(Some(&tools))
+            .unwrap_err();
 
-        // The namespace's member keeps its bare name — it isn't renamed to
-        // the colliding flat name already used by the top-level function.
-        assert_eq!(flat_function_count, 1);
-        assert!(matches!(&namespace.tools[0], CodexNamespaceMember::Function(f) if f.name.as_str() == "run"));
+        assert!(err.to_string().contains("collides with top-level function"));
     }
 
     #[test]
-    fn namespace_map_builder_detects_flat_name_collision_between_namespace_members() {
+    fn resolve_namespace_members_rejects_top_level_flat_name_collision() {
+        let tools: Vec<ResponsesTool> = serde_json::from_value(serde_json::json!([
+            {"type": "function", "name": "agentic_ns__mcp__shell__run"},
+            {
+                "type": "namespace",
+                "name": "mcp__shell",
+                "tools": [{"type": "function", "name": "run"}]
+            }
+        ]))
+        .unwrap();
+
+        let err = CodexNamespaceHandler.resolve_namespace_members(&tools).unwrap_err();
+
+        assert!(err.to_string().contains("collides with top-level function"));
+    }
+
+    #[test]
+    fn validate_namespace_collisions_rejects_generated_name_collision_between_namespace_members() {
+        let tools: Vec<ResponsesTool> = serde_json::from_value(serde_json::json!([
+            {
+                "type": "namespace",
+                "name": "a__b",
+                "tools": [{"type": "function", "name": "c"}]
+            },
+            {
+                "type": "namespace",
+                "name": "a",
+                "tools": [{"type": "function", "name": "b__c"}]
+            }
+        ]))
+        .unwrap();
+
+        let err = CodexNamespaceHandler
+            .validate_namespace_collisions(Some(&tools))
+            .unwrap_err();
+
+        assert!(err.to_string().contains("generated name"));
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "namespace collisions must be validated before recording namespace members")]
+    fn namespace_map_builder_debug_asserts_when_member_collision_validation_is_skipped() {
         let mut builder = NamespaceMapBuilder::new(HashSet::new());
 
-        assert_eq!(builder.record_flat_member("a__b", "c"), "agentic_ns__a__b__c");
-        assert_eq!(builder.flat_name_collision_count(), 0);
-        assert_eq!(builder.record_flat_member("a", "b__c"), "agentic_ns__a__b__c");
-        assert_eq!(builder.flat_name_collision_count(), 1);
+        assert_eq!(
+            builder.record_flat_member_with_flat_name("a__b", "c", "agentic_ns__a__b__c".to_owned()),
+            "agentic_ns__a__b__c"
+        );
+        let _ = builder.record_flat_member_with_flat_name("a", "b__c", "agentic_ns__a__b__c".to_owned());
     }
 
     #[test]
@@ -560,7 +645,9 @@ mod tests {
             "{\"tools\":\"legitimate\",\"cmd\":\"pwd\"}",
         )];
 
-        let map = CodexNamespaceHandler.build_namespace_map(Some(&tools));
+        let map = CodexNamespaceHandler
+            .build_namespace_map(Some(&tools))
+            .expect("valid namespace map");
         CodexNamespaceHandler.restore_output_items(&mut output, map.as_ref());
 
         let OutputItem::FunctionCall(call) = &output[0] else {
@@ -581,10 +668,14 @@ mod tests {
             }
         ]))
         .unwrap();
-        let resolved = CodexNamespaceHandler.resolve_namespace_members(&tools);
+        let resolved = CodexNamespaceHandler
+            .resolve_namespace_members(&tools)
+            .expect("valid namespace members");
         let mut output = vec![completed_call("get_weather", "{\"city\":\"SF\"}")];
 
-        let map = CodexNamespaceHandler.build_namespace_map(Some(&tools));
+        let map = CodexNamespaceHandler
+            .build_namespace_map(Some(&tools))
+            .expect("valid namespace map");
         CodexNamespaceHandler.restore_output_items(&mut output, map.as_ref());
 
         assert!(matches!(
@@ -619,7 +710,9 @@ mod tests {
             }
         });
 
-        let map = CodexNamespaceHandler.build_namespace_map(Some(&tools));
+        let map = CodexNamespaceHandler
+            .build_namespace_map(Some(&tools))
+            .expect("valid namespace map");
         assert!(CodexNamespaceHandler.restore_response_value(&mut value, map.as_ref()));
         assert_eq!(value["item"]["namespace"], "mcp__agentic_fixture");
         assert_eq!(value["item"]["name"], "add_numbers");

--- a/crates/agentic-core/src/tool/registry.rs
+++ b/crates/agentic-core/src/tool/registry.rs
@@ -72,20 +72,27 @@ pub struct ToolRegistry {
 impl ToolRegistry {
     /// Build a registry from the declared tools.
     ///
-    /// Function tools with empty names are skipped with a warning. Duplicate
-    /// tool names result in last-write-wins, also logged at `warn` level.
+    /// Duplicate tool names result in last-write-wins, logged at `warn` level.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ToolError::Config`] when Codex namespace member flattening
+    /// would collide with another declared tool name.
     ///
     /// # Panics
     ///
     /// Panics if serialization of a tool param struct fails, which cannot happen
     /// for the types defined in this module (`#[derive(Serialize)]` on plain structs).
-    #[must_use]
-    pub fn build(tools: &[ResponsesTool]) -> Self {
+    pub fn build(tools: &[ResponsesTool]) -> Result<Self, ToolError> {
         Self::build_with_handlers(tools, |_| None)
     }
 
-    #[must_use]
     /// Build a registry from declared tools and attach gateway handlers for dispatchable tool types.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ToolError::Config`] when Codex namespace member flattening
+    /// would collide with another declared tool name.
     ///
     /// # Panics
     ///
@@ -94,12 +101,12 @@ impl ToolRegistry {
     pub fn build_with_handlers(
         tools: &[ResponsesTool],
         mut handler_for: impl FnMut(ToolType) -> Option<Arc<dyn GatewayExecutor>>,
-    ) -> Self {
+    ) -> Result<Self, ToolError> {
         let mut entries = HashMap::with_capacity(tools.len());
         // Namespace members must be keyed by the same flat, model-visible name
         // the model will call, so resolve them first — the same pure pass used
         // to build the upstream request.
-        let resolved_tools = CodexNamespaceHandler.resolve_namespace_members(tools);
+        let resolved_tools = CodexNamespaceHandler.resolve_namespace_members(tools)?;
 
         for tool in &resolved_tools {
             match tool {
@@ -197,9 +204,9 @@ impl ToolRegistry {
             }
         }
 
-        let namespace_map = CodexNamespaceHandler.build_namespace_map((!tools.is_empty()).then_some(tools));
+        let namespace_map = CodexNamespaceHandler.build_namespace_map((!tools.is_empty()).then_some(tools))?;
 
-        Self { entries, namespace_map }
+        Ok(Self { entries, namespace_map })
     }
 
     #[must_use]

--- a/crates/agentic-core/src/types/io/tools.rs
+++ b/crates/agentic-core/src/types/io/tools.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de, ser::SerializeMap};
 use serde_json::Value;
 
-use crate::types::tools::ResponsesTool;
+use crate::types::tools::{NonEmptyToolName, ResponsesTool};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FunctionTool {
@@ -21,7 +21,7 @@ pub enum ToolChoice {
     Required,
     Function {
         namespace: Option<String>,
-        name: String,
+        name: NonEmptyToolName,
     },
 }
 
@@ -40,7 +40,7 @@ impl Serialize for ToolChoice {
                 if let Some(namespace) = namespace {
                     map.serialize_entry("namespace", namespace)?;
                 }
-                map.serialize_entry("name", name)?;
+                map.serialize_entry("name", name.as_str())?;
                 map.end()
             }
         }
@@ -70,10 +70,8 @@ impl<'de> Deserialize<'de> for ToolChoice {
                         .get("name")
                         .and_then(Value::as_str)
                         .ok_or_else(|| de::Error::missing_field("name"))?;
-                    return Ok(Self::Function {
-                        namespace,
-                        name: name.to_string(),
-                    });
+                    let name = NonEmptyToolName::try_from(name).map_err(de::Error::custom)?;
+                    return Ok(Self::Function { namespace, name });
                 }
 
                 if let Some(function) = object.get("function").and_then(Value::as_object) {
@@ -82,10 +80,8 @@ impl<'de> Deserialize<'de> for ToolChoice {
                         .get("name")
                         .and_then(Value::as_str)
                         .ok_or_else(|| de::Error::missing_field("name"))?;
-                    return Ok(Self::Function {
-                        namespace,
-                        name: name.to_string(),
-                    });
+                    let name = NonEmptyToolName::try_from(name).map_err(de::Error::custom)?;
+                    return Ok(Self::Function { namespace, name });
                 }
 
                 Err(de::Error::custom("expected tool_choice string or function object"))
@@ -122,5 +118,29 @@ pub(crate) fn resolve_tool_choice(
         request_choice.cloned().unwrap_or_default()
     } else {
         stored_choice.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn function_tool_choice_rejects_empty_name() {
+        assert!(
+            serde_json::from_value::<ToolChoice>(serde_json::json!({
+                "type": "function",
+                "name": ""
+            }))
+            .is_err()
+        );
+        assert!(
+            serde_json::from_value::<ToolChoice>(serde_json::json!({
+                "function": {
+                    "name": ""
+                }
+            }))
+            .is_err()
+        );
     }
 }

--- a/crates/agentic-core/src/types/request_response.rs
+++ b/crates/agentic-core/src/types/request_response.rs
@@ -5,7 +5,7 @@ use super::io::{
     FunctionTool, InputItem, InputMessage, InputMessageContent, OutputItem, ResponseUsage, ResponsesInput, ToolChoice,
 };
 use super::tools::ResponsesTool;
-use crate::tool::CodexNamespaceHandler;
+use crate::tool::{CodexNamespaceHandler, ToolError};
 use crate::utils::common::serialize_to_string;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -78,19 +78,25 @@ impl RequestPayload {
     /// All tool types are then normalised to `Vec<FunctionTool>` via
     /// [`ResponsesTool::to_function_tools`]. `tool_choice` is resolved the
     /// same way via [`CodexNamespaceHandler::resolve_tool_choice`].
-    #[must_use]
-    pub fn to_upstream_request(&self, stream: bool) -> UpstreamRequest<'_> {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ToolError::Config`] when a Codex namespace member's generated
+    /// flat name collides with a top-level function tool or another namespace
+    /// member.
+    pub fn to_upstream_request(&self, stream: bool) -> Result<UpstreamRequest<'_>, ToolError> {
         let renamed_tools = self
             .tools
             .as_deref()
-            .map(|tools| CodexNamespaceHandler.resolve_namespace_members(tools));
+            .map(|tools| CodexNamespaceHandler.resolve_namespace_members(tools))
+            .transpose()?;
         let tools: Option<Vec<FunctionTool>> = renamed_tools
             .as_deref()
             .map(|tools| tools.iter().flat_map(ResponsesTool::to_function_tools).collect());
         let tools = tools.filter(|tools| !tools.is_empty());
-        let namespace_map = CodexNamespaceHandler.build_namespace_map(self.tools.as_deref());
+        let namespace_map = CodexNamespaceHandler.build_namespace_map(self.tools.as_deref())?;
         let tool_choice = CodexNamespaceHandler.resolve_tool_choice(namespace_map.as_ref(), self.tool_choice.as_ref());
-        UpstreamRequest {
+        Ok(UpstreamRequest {
             model: &self.model,
             input: &self.input,
             stream,
@@ -103,7 +109,7 @@ impl RequestPayload {
             max_output_tokens: self.max_output_tokens,
             truncation: self.truncation.as_deref(),
             metadata: self.metadata.as_ref(),
-        }
+        })
     }
 }
 
@@ -202,7 +208,7 @@ mod tests {
         assert_eq!(payload.instructions.as_deref(), Some("rules"));
         assert!(matches!(&payload.input, ResponsesInput::Text(text) if text == "hi"));
 
-        let upstream = payload.to_upstream_request(false);
+        let upstream = payload.to_upstream_request(false).expect("valid upstream request");
         let value = serde_json::to_value(upstream).unwrap();
         assert_eq!(value["instructions"], "rules");
         assert_eq!(value["input"], "hi");
@@ -234,10 +240,33 @@ mod tests {
         };
         assert_eq!(namespace.tools.len(), 2);
 
-        let upstream = payload.to_upstream_request(false);
+        let upstream = payload.to_upstream_request(false).expect("valid upstream request");
         let value = serde_json::to_value(upstream).unwrap();
         assert_eq!(value["tools"].as_array().expect("upstream tools").len(), 1);
         assert_eq!(value["tools"][0]["name"], "agentic_ns__mcp__shell__run");
+    }
+
+    #[test]
+    fn to_upstream_request_rejects_namespace_collisions() {
+        let payload: RequestPayload = serde_json::from_value(serde_json::json!({
+            "model": "test",
+            "input": "hi",
+            "tools": [
+                {"type": "function", "name": "agentic_ns__mcp__shell__run"},
+                {
+                    "type": "namespace",
+                    "name": "mcp__shell",
+                    "tools": [{"type": "function", "name": "run"}]
+                }
+            ]
+        }))
+        .unwrap();
+
+        let Err(err) = payload.to_upstream_request(false) else {
+            panic!("colliding namespace member should be rejected");
+        };
+
+        assert!(err.to_string().contains("collides with top-level function"));
     }
 
     #[test]

--- a/crates/agentic-core/tests/stateful_responses_integration.rs
+++ b/crates/agentic-core/tests/stateful_responses_integration.rs
@@ -302,6 +302,36 @@ async fn test_codex_namespace_tool_shape_rehydrates_from_previous_response_metad
 }
 
 #[tokio::test]
+async fn test_codex_namespace_collision_with_top_level_function_is_rejected() {
+    let fixture = TestFixture::new_with_responses(vec![text_response("should not be called")]).await;
+    let tools: Vec<ResponsesTool> = serde_json::from_value(serde_json::json!([
+        {"type": "function", "name": "agentic_ns__mcp__shell__run"},
+        {
+            "type": "namespace",
+            "name": "mcp__shell",
+            "tools": [{"type": "function", "name": "run"}]
+        }
+    ]))
+    .unwrap();
+
+    let mut request = make_request("run pwd", true, false, None, None);
+    request.tools = Some(tools);
+
+    let Err(err) = execute(request, Arc::clone(&fixture.exec_ctx)).await else {
+        panic!("colliding namespace member should be rejected");
+    };
+
+    assert!(
+        err.to_string().contains("collides with top-level function"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        fixture.request_bodies().await.is_empty(),
+        "invalid request must fail before calling upstream"
+    );
+}
+
+#[tokio::test]
 async fn test_previous_response_id_explicit_tool_choice_overrides_stored_choice() {
     let fixture =
         TestFixture::new_with_responses(vec![text_response("seed answer"), text_response("next answer")]).await;

--- a/crates/agentic-core/tests/tool_normalization_test.rs
+++ b/crates/agentic-core/tests/tool_normalization_test.rs
@@ -87,8 +87,11 @@ fn upstream_request_value(payload: RequestPayload, stream: bool) -> Value {
         response_id: "resp_test".to_string(),
         conversation_id: None,
     };
-    let body =
-        serialize_to_string(&ctx.enriched_request.to_upstream_request(stream)).expect("serialize upstream request");
+    let upstream_request = ctx
+        .enriched_request
+        .to_upstream_request(stream)
+        .expect("valid upstream request");
+    let body = serialize_to_string(&upstream_request).expect("serialize upstream request");
     serde_json::from_str(&body).expect("upstream request should be JSON")
 }
 
@@ -116,7 +119,9 @@ fn assert_tools_normalize(cassette_file: &str) {
             continue;
         };
         let tools: Vec<ResponsesTool> = serde_json::from_value(tools_val).expect("tools parse");
-        let resolved = CodexNamespaceHandler.resolve_namespace_members(&tools);
+        let resolved = CodexNamespaceHandler
+            .resolve_namespace_members(&tools)
+            .unwrap_or_else(|err| panic!("{cassette_file} turn {i}: namespace resolution failed: {err}"));
         let normalized: Vec<_> = resolved.iter().flat_map(ResponsesTool::to_function_tools).collect();
         for ft in &normalized {
             assert_eq!(
@@ -160,7 +165,8 @@ fn assert_registry_lookup(cassette_file: &str) {
             continue;
         };
         let tools: Vec<ResponsesTool> = serde_json::from_value(tools_val).expect("tools parse");
-        let registry = ToolRegistry::build(&tools);
+        let registry = ToolRegistry::build(&tools)
+            .unwrap_or_else(|err| panic!("{cassette_file} turn {i}: registry failed: {err}"));
         for tool in &tools {
             if let ResponsesTool::Function(p) = tool {
                 let entry = registry
@@ -315,7 +321,9 @@ fn codex_namespace_cassettes_flatten_to_safe_upstream_function_name() {
                 "{filename} turn {i}: expected raw namespace tool"
             );
 
-            let resolved = CodexNamespaceHandler.resolve_namespace_members(&tools);
+            let resolved = CodexNamespaceHandler
+                .resolve_namespace_members(&tools)
+                .unwrap_or_else(|err| panic!("{filename} turn {i}: namespace resolution failed: {err}"));
             assert!(
                 resolved.iter().any(|tool| {
                     matches!(tool, ResponsesTool::Namespace(namespace)
@@ -357,7 +365,9 @@ fn codex_direct_vllm_flat_namespace_cassette_is_plain_function_tool() {
             "{filename} turn {i}: expected direct vLLM to see a plain function tool named {expected_flat_name}"
         );
 
-        let flattened = CodexNamespaceHandler.resolve_namespace_members(&tools);
+        let flattened = CodexNamespaceHandler
+            .resolve_namespace_members(&tools)
+            .unwrap_or_else(|err| panic!("{filename} turn {i}: namespace resolution failed: {err}"));
         assert_eq!(flattened.len(), 1);
         assert!(
             matches!(

--- a/docs/design/codex-integration.md
+++ b/docs/design/codex-integration.md
@@ -2,106 +2,117 @@
 
 > **References:** [Issue #54](https://github.com/vllm-project/agentic-api/issues/54),
 > [PR #67](https://github.com/vllm-project/agentic-api/pull/67)
-> **Owner:** @haoshan98 for Codex compatibility. Latest `main` owns the generic tool framework lineage from PR #67.
+> **Owner:** @haoshan98 for Codex compatibility. Latest `main` owns the shared tool framework lineage from PR #67.
 
 ---
 
 ## Summary
 
-`agentic-api` should work as an upstream layer for Codex CLI while routing inference to vLLM-supported models.
+`agentic-api` can sit between Codex CLI and a vLLM-backed Responses-compatible model endpoint.
 
-Post-merge status: the generic tool framework from latest `main` is now present. Codex tool wire shapes live in the
-shared `ResponsesTool` type, and namespace flatten/restore behavior lives in `tool::normalize`. The typed stateful
-executor forwards only vLLM-compatible `function` tools upstream after namespace flattening. Raw `store=false` proxying
-remains transparent and is intentionally outside this PR's Codex namespace normalization scope.
-
-This PR remains an MVP compatibility slice. It lets `agentic-api` accept and preserve Codex-used Responses traffic while
-plugging the Codex-specific compatibility rules into the shared tool framework.
+Codex can declare grouped tools with `type: "namespace"`, while vLLM-compatible upstreams accept ordinary
+`type: "function"` tool declarations. The gateway keeps the Codex-facing namespace shape at the request and storage
+boundary, flattens namespace members only when building the upstream request, and restores model-visible flat function
+calls back to Codex's public `{ namespace, name }` shape in final and streaming responses.
 
 The important split:
 
-- **Codex compatibility:** preserve Codex request/response shapes and continuation state.
-- **Shared framework:** provide generic tool normalization, execution, registry, ownership, and loop decisions.
+- **Codex compatibility:** preserve Codex request/response shapes, namespace identity, and continuation state.
+- **Shared framework:** provide generic tool normalization, registry ownership, gateway execution, and tool-loop
+  orchestration.
 
 ---
 
-## Current PR Scope
+## Implemented Scope
 
-This PR should do only the minimum needed for Codex compatibility:
+The current integration supports the typed stateful executor path:
 
-- Add this standalone design doc.
-- Accept Codex-used tool declarations without rejecting requests.
-- Preserve unknown tool declarations and unknown input/output items as raw JSON.
-- Preserve optional `namespace` on `function_call`.
-- Preserve `tool_search_call` and `custom_tool_call` shapes.
-- Preserve assistant tool-call items through `previous_response_id` rehydration.
-- Add lightweight helper types/tests that document what #67 should formalize later.
+- `ResponsesTool::Namespace` preserves the public Codex namespace declaration.
+- `CodexNamespaceHandler` owns Codex-specific namespace flattening and restoration.
+- `RequestPayload::to_upstream_request()` flattens namespace function members to vLLM-compatible function tools.
+- Namespaced `tool_choice` values are rewritten to the same flat names sent upstream.
+- `ToolRegistry` builds a request-scoped namespace map once and uses it for final payload and streaming event
+  restoration.
+- Stateful continuation stores effective tools, tool choice, instructions, and response/conversation linkage for later
+  `previous_response_id` or `conversation_id` turns.
+- WebSocket Responses execution uses the same typed executor path and restores namespace tool-call events before sending
+  them to clients.
 
-This PR should **not** build a second generic tool framework.
+Raw `store=false` proxying remains transparent. Namespace normalization intentionally lives in the typed executor path,
+not in the raw proxy path.
 
 ---
 
-## Shared Tool Framework Boundary
+## Namespace Flattening
 
-Latest `main` owns the formal shared tool system:
+The model-visible namespace member format is:
 
-- `ToolHandler` / `Tool` trait shape.
-- Generic tool normalization before `call_inference()`.
-- Request-scoped tool registry.
-- Client-owned vs gateway-owned dispatch.
-- Requires-action / client-action loop decision.
-- Live `execution_loop` orchestration and streaming tool events.
+```text
+agentic_ns__{namespace}__{member}
+```
 
-Codex-specific rules should stay plugged into those abstractions rather than reintroducing a parallel framework.
+For example, Codex can send:
+
+```json
+{
+  "type": "namespace",
+  "name": "mcp__agentic_fixture",
+  "tools": [
+    { "type": "function", "name": "add_numbers" }
+  ]
+}
+```
+
+The upstream request receives:
+
+```json
+{
+  "type": "function",
+  "name": "agentic_ns__mcp__agentic_fixture__add_numbers"
+}
+```
+
+When the model calls that flat function, the gateway restores:
+
+```json
+{
+  "type": "function_call",
+  "namespace": "mcp__agentic_fixture",
+  "name": "add_numbers"
+}
+```
+
+---
+
+## Collision Handling
+
+The `agentic_ns__` prefix marks gateway-generated namespace member names. If a declared top-level function already uses
+the generated name for a namespace member, or if two namespace members generate the same flat name, the typed executor
+rejects the request as invalid. Forwarding either shape would make a later model call ambiguous and impossible to restore
+reliably to `{ namespace, name }`.
 
 ---
 
 ## Compatibility Rules
 
-The gateway should not detect requests by user agent, route, or "is this Codex?" heuristics. Compatibility is
-driven by Responses tool shapes and execution semantics, so it can be always on.
+The gateway should not detect requests by user agent, route, or "is this Codex?" heuristics. Compatibility is driven by
+Responses tool shapes and execution semantics, so it can be always on.
 
 | Shape | Behavior |
 |-------|----------|
 | `function` | Client-owned by default. Preserve declaration and return matching calls to the client unless configured as gateway-owned. |
-| `namespace` | Model-facing grouping for function tools. Do not treat namespace as a separate executable call type. |
-| `tool_search` | Client-owned only when `execution == "client"`. Hosted/non-client search is provider-owned. |
-| `custom` | Client-owned by default. Preserve free-form / grammar metadata. |
-| Unknown tool | Preserve as raw JSON. Never execute by default. |
+| `namespace` | Client-owned Codex grouping for function tools. Flatten members only for upstream requests, then restore returned calls. |
+| `web_search_preview` | Gateway-owned when configured; normalized to the gateway web-search function tool. |
+| `mcp`, `file_search`, `code_interpreter` | Preserve typed request shape; only forward once a gateway handler supports that tool kind. |
+| Unknown tool | Preserve as raw-compatible unknown data where supported. Never execute by default. |
 
 For response items:
 
 | Response item | Behavior |
 |---------------|----------|
-| `function_call` | Preserve optional `namespace`. |
-| `tool_search_call` with `execution == "client"` | Return to the client for local deferred discovery. |
-| Hosted / non-client `tool_search_call` | Do not execute locally. Leave to provider-specific handling. |
-| `custom_tool_call` | Preserve free-form `input`; do not coerce into JSON function arguments. |
-| Unknown output item | Preserve as raw JSON. Never execute by default. |
-
----
-
-## Requirements For #67
-
-The generic framework should preserve enough metadata for Codex-compatible behavior:
-
-- raw original tool JSON
-- model-visible tool name
-- original client-visible identity
-- optional namespace or an equivalent unambiguous key
-- execution owner: `Client`, `Gateway`, or provider-owned
-- raw hints such as `execution`, `format`, and `defer_loading`
-
-If namespaced tools need disambiguation, a split identity is useful:
-
-```rust
-pub struct ToolName {
-    pub namespace: Option<String>,
-    pub name: String,
-}
-```
-
-This avoids collisions such as two different namespaces both defining a tool named `run`.
+| `function_call` | Preserve optional `namespace`; restore flat namespace calls before returning to Codex. |
+| `web_search_call` | Gateway-owned result from the web-search executor. |
+| Unknown output item | Preserve raw-compatible data where supported. Never execute by default. |
 
 ---
 
@@ -115,28 +126,15 @@ Expected rehydration shape:
 prior context + assistant tool call + Codex tool output + new input
 ```
 
-On a turn that returns client-owned tool calls, storage should keep the assistant call item. On the next turn, Codex
-submits the matching tool output item, and `previous_response_id` should rebuild the full sequence.
+On a turn that returns client-owned tool calls, storage keeps the assistant call item. On the next turn, Codex submits
+the matching tool output item, and `previous_response_id` rebuilds the full sequence while preserving effective tool
+metadata from the previous response unless the client explicitly overrides it.
 
 ---
 
-## Test Plan
+## Out Of Scope
 
-Current PR tests should cover:
-
-- `function`, `namespace`, `tool_search`, `custom`, and unknown tools round-trip.
-- Extra fields remain preserved.
-- `function_call.namespace` round-trips.
-- `tool_search_call` and `custom_tool_call` remain raw-compatible.
-- Unknown input/output items remain raw JSON.
-- `previous_response_id` rehydrates assistant tool calls before tool outputs.
-
-Post-#67 tests should prove the same behavior through the formal tool framework.
-
----
-
-## Open Questions
-
-1. What exact requires-action payload type should #67 expose?
-2. Should #67 use split `ToolName { namespace, name }` or a different unambiguous registry key?
-3. Which Codex-used fields should become typed framework fields, and which should remain raw metadata?
+- Raw proxy namespace flatten/restore.
+- Gateway-side model aliasing.
+- A gateway-side Codex runtime.
+- Executing Codex namespace tools in the gateway. Codex still owns client-side tool execution.


### PR DESCRIPTION
## Summary

- reject Codex namespace declarations whose generated flat names collide with a declared top-level function or another namespace member before building the upstream request
- make namespace member resolution, registry construction, and `RequestPayload::to_upstream_request` fallible so direct callers cannot bypass collision validation
- validate named `tool_choice` values with the existing `NonEmptyToolName` type so empty function choices are rejected at the serde boundary
- refresh the Codex integration design doc to describe the current typed executor namespace flatten/restore path and collision behavior

## Test Plan

- `cargo fmt -- --check`
- `cargo test -p agentic-core --test stateful_responses_integration test_codex_namespace_collision_with_top_level_function_is_rejected --quiet`
- `cargo test -p agentic-core tool::codex::tests --quiet`
- `cargo test -p agentic-core --test tool_normalization_test --quiet`
- `cargo test -p agentic-core codex --quiet`
- `cargo clippy -p agentic-core --tests -- -D warnings`
- `git diff --check`
- `cargo test -p agentic-core --quiet`