### PR TITLE
fix: tune SQLite concurrency and add mixed read/write coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ target/
 # db
 *.db
 *.db-journal
+*.db-shm
+*.db-wal

--- a/crates/agentic-server-core/benches/storage_concurrent.rs
+++ b/crates/agentic-server-core/benches/storage_concurrent.rs
@@ -9,6 +9,7 @@
 //! | `concurrent_conversation_persist_independent`| N writers each to their **own** conversation         |
 //! | `concurrent_conversation_rehydrate`          | N readers of the **same** conversation               |
 //! | `concurrent_conversation_rehydrate_independent` | N readers each on their **own** conversation      |
+//! | `concurrent_conversation_mixed_read_write` | 1 writer and N readers across independent `SQLite` pools |
 //! | `concurrent_response_persist`               | N independent response writes in parallel            |
 //! | `concurrent_response_rehydrate`             | N readers of the **same** response                  |
 //!
@@ -294,6 +295,81 @@ fn bench_concurrent_conversation_rehydrate_independent(c: &mut Criterion, store:
     group.finish();
 }
 
+fn bench_concurrent_conversation_mixed_read_write(c: &mut Criterion) {
+    let mut group = c.benchmark_group("concurrent_conversation_mixed_read_write");
+
+    for concurrency in concurrency_levels() {
+        group.throughput(Throughput::Elements((concurrency + 1) as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(concurrency),
+            &concurrency,
+            |b, &concurrency| {
+                b.to_async(Runtime::new().unwrap()).iter_batched(
+                    || async move {
+                        let db_path =
+                            std::env::temp_dir().join(format!("storage_mixed_rw_{}.db", uuid::Uuid::now_v7()));
+                        let db_url = format!("sqlite://{}", db_path.display());
+                        let writer_pool = create_pool_with_schema(Some(&db_url)).await.expect("writer pool");
+                        let reader_pool = create_pool_with_schema(Some(&db_url)).await.expect("reader pool");
+                        let writer_store = ConversationStore::new(writer_pool);
+                        let reader_store = ConversationStore::new(reader_pool);
+                        let conversation_id = writer_store
+                            .create()
+                            .await
+                            .expect("create conversation")
+                            .conversation_id;
+                        writer_store
+                            .persist(&conversation_id, &next_id(), None, make_items(), &make_metadata())
+                            .await
+                            .expect("seed conversation");
+                        (Arc::new(writer_store), Arc::new(reader_store), conversation_id)
+                    },
+                    |setup| async move {
+                        let (writer_store, reader_store, conversation_id) = setup.await;
+                        let writer_id = conversation_id.clone();
+                        let writer = {
+                            let writer_store = writer_store.clone();
+                            tokio::spawn(async move {
+                                writer_store
+                                    .persist(
+                                        &writer_id,
+                                        &next_id(),
+                                        None,
+                                        black_box(make_items()),
+                                        &black_box(make_metadata()),
+                                    )
+                                    .await
+                                    .expect("mixed writer failed");
+                            })
+                        };
+
+                        let readers: Vec<_> = (0..concurrency)
+                            .map(|_| {
+                                let reader_store = reader_store.clone();
+                                let reader_id = conversation_id.clone();
+                                tokio::spawn(async move {
+                                    reader_store
+                                        .rehydrate(&black_box(reader_id))
+                                        .await
+                                        .expect("mixed reader failed")
+                                })
+                            })
+                            .collect();
+
+                        writer.await.expect("writer task panicked");
+                        for reader in readers {
+                            reader.await.expect("reader task panicked");
+                        }
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
 fn bench_concurrent_response_persist(c: &mut Criterion, store: &ResponseStore) {
     let store = Arc::new(store.clone());
     let mut group = c.benchmark_group("concurrent_response_persist");
@@ -409,6 +485,7 @@ fn init_benches(c: &mut Criterion) {
     bench_concurrent_conversation_persist_independent(c, &conversation_store);
     bench_concurrent_conversation_rehydrate(c, &conversation_store);
     bench_concurrent_conversation_rehydrate_independent(c, &conversation_store);
+    bench_concurrent_conversation_mixed_read_write(c);
     bench_concurrent_response_persist(c, &response_store);
     bench_concurrent_response_rehydrate(c, &response_store);
 

--- a/crates/agentic-server-core/src/config.rs
+++ b/crates/agentic-server-core/src/config.rs
@@ -1,3 +1,45 @@
+pub const DEFAULT_SQLITE_MAX_CONNECTIONS: u32 = 4;
+pub const DEFAULT_SQLITE_JOURNAL_SIZE_LIMIT_BYTES: u64 = 6_144_000;
+pub const DEFAULT_SQLITE_MMAP_SIZE_BYTES: u64 = 268_435_456;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SqliteTempStore {
+    Default,
+    File,
+    #[default]
+    Memory,
+}
+
+impl SqliteTempStore {
+    #[must_use]
+    pub fn as_pragma_value(self) -> &'static str {
+        match self {
+            Self::Default => "DEFAULT",
+            Self::File => "FILE",
+            Self::Memory => "MEMORY",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SqliteConfig {
+    pub max_connections: u32,
+    pub journal_size_limit_bytes: u64,
+    pub temp_store: SqliteTempStore,
+    pub mmap_size_bytes: u64,
+}
+
+impl Default for SqliteConfig {
+    fn default() -> Self {
+        Self {
+            max_connections: DEFAULT_SQLITE_MAX_CONNECTIONS,
+            journal_size_limit_bytes: DEFAULT_SQLITE_JOURNAL_SIZE_LIMIT_BYTES,
+            temp_store: SqliteTempStore::default(),
+            mmap_size_bytes: DEFAULT_SQLITE_MMAP_SIZE_BYTES,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Config {
     pub llm_api_base: String,
@@ -8,6 +50,7 @@ pub struct Config {
     /// Database URL for conversation and response storage.
     /// `None` means stateful features are disabled; all requests are proxied.
     pub db_url: Option<String>,
+    pub sqlite: SqliteConfig,
 }
 
 #[must_use]

--- a/crates/agentic-server-core/src/executor/request.rs
+++ b/crates/agentic-server-core/src/executor/request.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use crate::config::Config;
 use crate::error::Error;
 use crate::executor::modes::{ConversationHandler, ResponseHandler};
-use crate::storage::{ConversationStore, ResponseStore, create_pool_with_schema};
+use crate::storage::{ConversationStore, ResponseStore, create_pool_with_schema_and_sqlite_config};
 use crate::tool::{GatewayExecutor, ToolType, WebSearchHandler};
 use crate::types::io::InputItem;
 use crate::types::request_response::{RequestPayload, ResponsePayload};
@@ -144,7 +144,7 @@ impl ExecutionContext {
     /// migration fails.
     pub async fn from_config(cfg: &Config) -> Result<Self, Error> {
         let db_url = cfg.db_url.as_deref().unwrap_or("sqlite://./agentic_api.db");
-        let pool = create_pool_with_schema(Some(db_url))
+        let pool = create_pool_with_schema_and_sqlite_config(Some(db_url), cfg.sqlite)
             .await
             .map_err(|e| Error::Config(format!("failed to open database '{db_url}': {e}")))?;
 

--- a/crates/agentic-server-core/src/proxy.rs
+++ b/crates/agentic-server-core/src/proxy.rs
@@ -275,6 +275,7 @@ mod tests {
             llm_ready_interval_s: 0.1,
             skip_llm_ready_check: false,
             db_url: None,
+            sqlite: crate::config::SqliteConfig::default(),
         }
     }
 

--- a/crates/agentic-server-core/src/storage/conversation.rs
+++ b/crates/agentic-server-core/src/storage/conversation.rs
@@ -108,17 +108,12 @@ impl ConversationStore {
             let data_str = String::try_from(&any_item)?;
             items_.push((item_id, data_str));
         }
+        let history_item_ids_json = serialize_to_string(&item_ids)?;
+        let metadata_json = String::try_from(metadata)?;
 
         let mut tx = pool.begin().await?;
 
-        let seq_start = item::conversation_item_count(&mut tx, conversation_id)
-            .await?
-            .ok_or_else(|| StorageError::not_found("Conversation", conversation_id))?;
-
-        item::create_in_tx(&mut tx, items_, Some(conversation_id), Some(seq_start)).await?;
-
-        let history_item_ids_json = serialize_to_string(&item_ids)?;
-        let metadata_json = String::try_from(metadata)?;
+        item::create_in_tx(&mut tx, items_, Some(conversation_id)).await?;
 
         response::create_in_tx(
             &mut tx,

--- a/crates/agentic-server-core/src/storage/mod.rs
+++ b/crates/agentic-server-core/src/storage/mod.rs
@@ -23,7 +23,10 @@ pub use conversation::ConversationStore;
 pub use models::Conversation as DbConversation;
 pub use models::Item;
 pub use models::Response as DbResponse;
-pub use pool::{DbPool, DbResult, DbTransaction, create_pool, create_pool_with_schema};
+pub use pool::{
+    DbPool, DbResult, DbTransaction, create_pool, create_pool_with_schema, create_pool_with_schema_and_sqlite_config,
+    create_pool_with_sqlite_config,
+};
 pub use response::ResponseStore;
 pub use schema::{PoolWithSchema, SchemaManager};
 pub use types::{ConversationData, InOutItem, ItemKind, ResponseData, ResponseMetadata, StorageError, StoreResult};

--- a/crates/agentic-server-core/src/storage/models/item.rs
+++ b/crates/agentic-server-core/src/storage/models/item.rs
@@ -90,8 +90,8 @@ impl Item {
 
 /// Create items in a transaction with optional conversation context.
 ///
-/// If `conversation_id` and `seq_start` are provided, items are created with sequence numbers.
-/// Otherwise, items are created without conversation context.
+/// If `conversation_id` is provided, the next sequence range is computed in the insert statement so
+/// concurrent `SQLite` writers do not take a stale read snapshot before writing.
 ///
 /// # Errors
 /// Returns `DbResult::Err` if the database insertion fails.
@@ -99,10 +99,13 @@ pub async fn create_in_tx(
     tx: &mut DbTransaction<'_>,
     items: Vec<(String, String)>,
     conversation_id: Option<&str>,
-    seq_start: Option<i64>,
 ) -> DbResult<Vec<Item>> {
     if items.is_empty() {
         return Ok(Vec::new());
+    }
+
+    if let Some(conversation_id) = conversation_id {
+        return create_in_tx_with_next_conversation_seq(tx, items, conversation_id).await;
     }
 
     let now = utcnow_str();
@@ -112,10 +115,41 @@ pub async fn create_in_tx(
         format!("INSERT INTO items (id, data, created_at, conversation_id, seq) VALUES {values_clause} RETURNING *");
 
     let mut query = sqlx::query_as::<_, Item>(&sql);
+    for (id, data) in &items {
+        query = query.bind(id).bind(data).bind(now).bind(None::<&str>).bind(None::<i64>);
+    }
+
+    query.fetch_all(&mut **tx).await
+}
+
+async fn create_in_tx_with_next_conversation_seq(
+    tx: &mut DbTransaction<'_>,
+    items: Vec<(String, String)>,
+    conversation_id: &str,
+) -> DbResult<Vec<Item>> {
+    let now = utcnow_str();
+    let placeholders: Vec<&str> = vec!["(?, ?, ?, ?, (SELECT start + ? FROM next_seq))"; items.len()];
+    let values_clause = placeholders.join(", ");
+    let sql = format!(
+        "WITH next_seq AS ( \
+             SELECT COALESCE(MAX(seq), -1) + 1 AS start \
+             FROM items \
+             WHERE conversation_id = ? \
+         ) \
+         INSERT INTO items (id, data, created_at, conversation_id, seq) \
+         VALUES {values_clause} \
+         RETURNING *"
+    );
+
+    let mut query = sqlx::query_as::<_, Item>(&sql).bind(conversation_id);
     #[allow(clippy::cast_possible_wrap)]
     for (idx, (id, data)) in items.iter().enumerate() {
-        let seq = seq_start.map(|start| start + idx as i64);
-        query = query.bind(id).bind(data).bind(now).bind(conversation_id).bind(seq);
+        query = query
+            .bind(id)
+            .bind(data)
+            .bind(now)
+            .bind(conversation_id)
+            .bind(idx as i64);
     }
 
     query.fetch_all(&mut **tx).await
@@ -147,23 +181,6 @@ pub async fn get_items_by_conversation(pool: &DbPool, conversation_id: &str) -> 
         .bind(conversation_id)
         .fetch_all(pool)
         .await
-}
-
-/// Get next sequence number for items in a conversation, within a transaction.
-///
-/// Reading inside the transaction ensures concurrent writers serialize on the same
-/// connection and cannot both claim the same sequence range.
-///
-/// # Errors
-/// Returns `DbResult::Err` if the database query fails.
-pub async fn conversation_item_count(tx: &mut DbTransaction<'_>, conversation_id: &str) -> DbResult<Option<i64>> {
-    let max_seq: Option<i64> = sqlx::query_scalar("SELECT MAX(seq) FROM items WHERE conversation_id = ?")
-        .bind(conversation_id)
-        .fetch_optional(&mut **tx)
-        .await?
-        .flatten();
-
-    Ok(Some(max_seq.unwrap_or(-1) + 1))
 }
 
 #[cfg(test)]

--- a/crates/agentic-server-core/src/storage/pool.rs
+++ b/crates/agentic-server-core/src/storage/pool.rs
@@ -2,7 +2,14 @@
 
 use std::sync::Arc;
 
+use sqlx::AnyConnection;
 use sqlx::any::AnyPoolOptions;
+
+use crate::config::SqliteConfig;
+
+const SQLITE_MEMORY_MAX_CONNECTIONS: u32 = 1;
+const DEFAULT_MAX_CONNECTIONS: u32 = 10;
+const SQLITE_BUSY_TIMEOUT_MS: u64 = 5_000;
 
 /// Generic database pool type supporting `SQLite`, `PostgreSQL`, and `MySQL`.
 pub type DbPool = sqlx::Pool<sqlx::Any>;
@@ -24,17 +31,83 @@ pub type DbResult<T> = Result<T, sqlx::Error>;
 /// Defaults to `sqlite://./agentic_api.db` if no URL is provided.
 fn prepare_db_url(url: Option<&str>) -> String {
     let url = url.unwrap_or("sqlite://./agentic_api.db");
-    if url.starts_with("sqlite") && !url.contains('?') {
-        format!("{url}?mode=rwc")
-    } else {
+    if !url.starts_with("sqlite") || has_query_param(url, "mode") {
         url.to_string()
+    } else {
+        append_query_param(url, "mode=rwc")
     }
+}
+
+fn has_query_param(url: &str, param: &str) -> bool {
+    query_param_value(url, param).is_some()
+}
+
+fn query_param_value<'a>(url: &'a str, param: &str) -> Option<&'a str> {
+    let (_, query) = url.split_once('?')?;
+    let query = query.split_once('#').map_or(query, |(query, _)| query);
+    query.split('&').find_map(|part| {
+        let (key, value) = part.split_once('=').map_or((part, ""), |(key, value)| (key, value));
+        (key == param).then_some(value)
+    })
+}
+
+fn append_query_param(url: &str, param: &str) -> String {
+    let (base, fragment) = url
+        .split_once('#')
+        .map_or((url, None), |(base, fragment)| (base, Some(fragment)));
+    let separator = if base.contains('?') { '&' } else { '?' };
+    let mut prepared = format!("{base}{separator}{param}");
+    if let Some(fragment) = fragment {
+        prepared.push('#');
+        prepared.push_str(fragment);
+    }
+    prepared
+}
+
+fn sqlite_is_memory_url(url: &str) -> bool {
+    query_param_value(url, "mode").is_some_and(|mode| mode.eq_ignore_ascii_case("memory")) || url.contains(":memory:")
+}
+
+fn sqlite_should_enable_wal(url: &str) -> bool {
+    url.starts_with("sqlite")
+        && !sqlite_is_memory_url(url)
+        && !query_param_value(url, "mode").is_some_and(|mode| mode.eq_ignore_ascii_case("ro"))
+}
+
+fn sqlite_max_connections(url: &str, config: SqliteConfig) -> u32 {
+    if sqlite_is_memory_url(url) {
+        SQLITE_MEMORY_MAX_CONNECTIONS
+    } else {
+        config.max_connections
+    }
+}
+
+async fn configure_sqlite_connection(conn: &mut AnyConnection, config: SqliteConfig) -> DbResult<()> {
+    sqlx::query(&format!("PRAGMA busy_timeout = {SQLITE_BUSY_TIMEOUT_MS}"))
+        .execute(&mut *conn)
+        .await?;
+    sqlx::query(&format!(
+        "PRAGMA journal_size_limit = {}",
+        config.journal_size_limit_bytes
+    ))
+    .execute(&mut *conn)
+    .await?;
+    sqlx::query(&format!("PRAGMA temp_store = {}", config.temp_store.as_pragma_value()))
+        .execute(&mut *conn)
+        .await?;
+    sqlx::query(&format!("PRAGMA mmap_size = {}", config.mmap_size_bytes))
+        .execute(&mut *conn)
+        .await?;
+    sqlx::query("PRAGMA foreign_keys = ON").execute(&mut *conn).await?;
+    sqlx::query("PRAGMA synchronous = NORMAL").execute(&mut *conn).await?;
+
+    Ok(())
 }
 
 /// Creates a connection pool for the database.
 ///
 /// Initializes a connection pool with sensible defaults:
-/// - Max connections: 10 (configurable via [`AnyPoolOptions`])
+/// - Max connections: 4 for file-backed `SQLite`, 1 for in-memory `SQLite`, 10 for other databases
 /// - Driver auto-detection: supports `SQLite`, `PostgreSQL`, `MySQL`
 /// - `SQLite` file mode: read-write-create for file-based databases
 ///
@@ -54,20 +127,37 @@ fn prepare_db_url(url: Option<&str>) -> String {
 /// - Authentication fails
 ///
 pub async fn create_pool(db_url: Option<&str>) -> DbResult<Arc<DbPool>> {
+    create_pool_with_sqlite_config(db_url, SqliteConfig::default()).await
+}
+
+/// Creates a connection pool for the database with explicit `SQLite` tuning.
+///
+/// # Errors
+///
+/// Returns [`sqlx::Error`] if pool creation or connection initialization fails.
+pub async fn create_pool_with_sqlite_config(
+    db_url: Option<&str>,
+    sqlite_config: SqliteConfig,
+) -> DbResult<Arc<DbPool>> {
     // Install default drivers for auto-detection
     sqlx::any::install_default_drivers();
 
     // Prepare URL with database-specific parameters
     let url = prepare_db_url(db_url);
 
-    // SQLite only allows one writer at a time; a single connection in the pool
-    // serializes writes at the pool level (queue).
-    // For other databases, 10 connections is a conservative default.
-    let max_connections = if url.starts_with("sqlite") { 1 } else { 10 };
-    let pool = AnyPoolOptions::new()
-        .max_connections(max_connections)
-        .connect(&url)
-        .await?;
+    let max_connections = if url.starts_with("sqlite") {
+        sqlite_max_connections(&url, sqlite_config)
+    } else {
+        DEFAULT_MAX_CONNECTIONS
+    };
+    let mut options = AnyPoolOptions::new().max_connections(max_connections);
+    if url.starts_with("sqlite") {
+        options = options.after_connect(move |conn, _meta| Box::pin(configure_sqlite_connection(conn, sqlite_config)));
+    }
+    let pool = options.connect(&url).await?;
+    if sqlite_should_enable_wal(&url) {
+        sqlx::query("PRAGMA journal_mode = WAL").execute(&pool).await?;
+    }
 
     // Wrap in Arc for thread-safe sharing across async tasks
     Ok(Arc::new(pool))
@@ -85,9 +175,21 @@ pub async fn create_pool(db_url: Option<&str>) -> DbResult<Arc<DbPool>> {
 ///
 /// Returns error if pool creation or schema initialization fails.
 pub async fn create_pool_with_schema(db_url: Option<&str>) -> DbResult<Arc<DbPool>> {
+    create_pool_with_schema_and_sqlite_config(db_url, SqliteConfig::default()).await
+}
+
+/// Creates a connection pool with explicit `SQLite` tuning and initializes the database schema.
+///
+/// # Errors
+///
+/// Returns error if pool creation or schema initialization fails.
+pub async fn create_pool_with_schema_and_sqlite_config(
+    db_url: Option<&str>,
+    sqlite_config: SqliteConfig,
+) -> DbResult<Arc<DbPool>> {
     use crate::storage::PoolWithSchema;
 
-    let pool = create_pool(db_url).await?;
+    let pool = create_pool_with_sqlite_config(db_url, sqlite_config).await?;
     let pool_with_schema = PoolWithSchema::new(pool);
     pool_with_schema.ensure_schema_ready().await?;
 
@@ -97,6 +199,10 @@ pub async fn create_pool_with_schema(db_url: Option<&str>) -> DbResult<Arc<DbPoo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{
+        DEFAULT_SQLITE_JOURNAL_SIZE_LIMIT_BYTES, DEFAULT_SQLITE_MAX_CONNECTIONS, DEFAULT_SQLITE_MMAP_SIZE_BYTES,
+        SqliteTempStore,
+    };
 
     #[test]
     fn test_prepare_sqlite_url_without_params() {
@@ -109,7 +215,55 @@ mod tests {
     fn test_prepare_sqlite_url_with_params() {
         let url = "sqlite://test.db?cache=shared";
         let prepared = prepare_db_url(Some(url));
-        assert_eq!(prepared, "sqlite://test.db?cache=shared");
+        assert_eq!(prepared, "sqlite://test.db?cache=shared&mode=rwc");
+    }
+
+    #[test]
+    fn test_prepare_sqlite_url_with_fragment() {
+        let url = "sqlite://test.db?cache=shared#frag";
+        let prepared = prepare_db_url(Some(url));
+        assert_eq!(prepared, "sqlite://test.db?cache=shared&mode=rwc#frag");
+    }
+
+    #[test]
+    fn test_prepare_sqlite_url_with_existing_mode() {
+        let url = "sqlite://test.db?mode=ro";
+        let prepared = prepare_db_url(Some(url));
+        assert_eq!(prepared, "sqlite://test.db?mode=ro");
+    }
+
+    #[test]
+    fn test_prepare_sqlite_memory_url_keeps_memory_mode() {
+        let url = "sqlite://?mode=memory";
+        let prepared = prepare_db_url(Some(url));
+        assert_eq!(prepared, "sqlite://?mode=memory");
+    }
+
+    #[test]
+    fn test_sqlite_wal_enabled_for_writable_file_urls_only() {
+        assert!(sqlite_should_enable_wal("sqlite://test.db?mode=rwc"));
+        assert!(sqlite_should_enable_wal("sqlite://test.db?mode=rw"));
+        assert!(!sqlite_should_enable_wal("sqlite://test.db?mode=ro"));
+        assert!(!sqlite_should_enable_wal("sqlite://?mode=memory"));
+        assert!(!sqlite_should_enable_wal("sqlite::memory:"));
+    }
+
+    #[test]
+    fn test_sqlite_max_connections_for_file_and_memory_urls() {
+        let config = SqliteConfig {
+            max_connections: 6,
+            ..SqliteConfig::default()
+        };
+
+        assert_eq!(sqlite_max_connections("sqlite://test.db?mode=rwc", config), 6);
+        assert_eq!(
+            sqlite_max_connections("sqlite://?mode=memory", config),
+            SQLITE_MEMORY_MAX_CONNECTIONS
+        );
+        assert_eq!(
+            sqlite_max_connections("sqlite::memory:", config),
+            SQLITE_MEMORY_MAX_CONNECTIONS
+        );
     }
 
     #[test]
@@ -130,5 +284,105 @@ mod tests {
     fn test_prepare_default_sqlite_url() {
         let prepared = prepare_db_url(None);
         assert_eq!(prepared, "sqlite://./agentic_api.db?mode=rwc");
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_connection_pragmas_are_configured() {
+        let db_path = std::env::temp_dir().join(format!("pragma_{}.db", uuid::Uuid::now_v7()));
+        let db_url = format!("sqlite://{}", db_path.display());
+        let pool = create_pool(Some(&db_url)).await.expect("failed to create pool");
+
+        let journal_mode: String = sqlx::query_scalar("PRAGMA journal_mode")
+            .fetch_one(pool.as_ref())
+            .await
+            .expect("journal_mode query failed");
+        let busy_timeout: i64 = sqlx::query_scalar("PRAGMA busy_timeout")
+            .fetch_one(pool.as_ref())
+            .await
+            .expect("busy_timeout query failed");
+        let foreign_keys: i64 = sqlx::query_scalar("PRAGMA foreign_keys")
+            .fetch_one(pool.as_ref())
+            .await
+            .expect("foreign_keys query failed");
+        let synchronous: i64 = sqlx::query_scalar("PRAGMA synchronous")
+            .fetch_one(pool.as_ref())
+            .await
+            .expect("synchronous query failed");
+        let journal_size_limit: i64 = sqlx::query_scalar("PRAGMA journal_size_limit")
+            .fetch_one(pool.as_ref())
+            .await
+            .expect("journal_size_limit query failed");
+        let temp_store: i64 = sqlx::query_scalar("PRAGMA temp_store")
+            .fetch_one(pool.as_ref())
+            .await
+            .expect("temp_store query failed");
+        let mmap_size: i64 = sqlx::query_scalar("PRAGMA mmap_size")
+            .fetch_one(pool.as_ref())
+            .await
+            .expect("mmap_size query failed");
+
+        assert_eq!(journal_mode.to_lowercase(), "wal");
+        assert_eq!(pool.options().get_max_connections(), DEFAULT_SQLITE_MAX_CONNECTIONS);
+        assert_eq!(
+            busy_timeout,
+            i64::try_from(SQLITE_BUSY_TIMEOUT_MS).expect("default fits in i64")
+        );
+        assert_eq!(foreign_keys, 1);
+        assert_eq!(synchronous, 1);
+        assert_eq!(
+            journal_size_limit,
+            i64::try_from(DEFAULT_SQLITE_JOURNAL_SIZE_LIMIT_BYTES).expect("default fits in i64")
+        );
+        assert_eq!(temp_store, 2);
+        assert_eq!(
+            mmap_size,
+            i64::try_from(DEFAULT_SQLITE_MMAP_SIZE_BYTES).expect("default fits in i64")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_connection_pragmas_use_explicit_config() {
+        let db_path = std::env::temp_dir().join(format!("pragma_custom_{}.db", uuid::Uuid::now_v7()));
+        let db_url = format!("sqlite://{}", db_path.display());
+        let config = SqliteConfig {
+            max_connections: 3,
+            journal_size_limit_bytes: 131_072,
+            temp_store: SqliteTempStore::File,
+            mmap_size_bytes: 1_048_576,
+        };
+        let pool = create_pool_with_sqlite_config(Some(&db_url), config)
+            .await
+            .expect("failed to create pool");
+
+        let journal_size_limit: i64 = sqlx::query_scalar("PRAGMA journal_size_limit")
+            .fetch_one(pool.as_ref())
+            .await
+            .expect("journal_size_limit query failed");
+        let temp_store: i64 = sqlx::query_scalar("PRAGMA temp_store")
+            .fetch_one(pool.as_ref())
+            .await
+            .expect("temp_store query failed");
+        let mmap_size: i64 = sqlx::query_scalar("PRAGMA mmap_size")
+            .fetch_one(pool.as_ref())
+            .await
+            .expect("mmap_size query failed");
+
+        assert_eq!(pool.options().get_max_connections(), 3);
+        assert_eq!(journal_size_limit, 131_072);
+        assert_eq!(temp_store, 1);
+        assert_eq!(mmap_size, 1_048_576);
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_memory_pool_stays_single_connection() {
+        let config = SqliteConfig {
+            max_connections: 3,
+            ..SqliteConfig::default()
+        };
+        let pool = create_pool_with_sqlite_config(Some("sqlite://?mode=memory"), config)
+            .await
+            .expect("failed to create pool");
+
+        assert_eq!(pool.options().get_max_connections(), SQLITE_MEMORY_MAX_CONNECTIONS);
     }
 }

--- a/crates/agentic-server-core/src/storage/pool.rs
+++ b/crates/agentic-server-core/src/storage/pool.rs
@@ -1,6 +1,6 @@
 //! Database connection pooling and initialization.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use sqlx::AnyConnection;
 use sqlx::any::AnyPoolOptions;
@@ -10,6 +10,10 @@ use crate::config::SqliteConfig;
 const SQLITE_MEMORY_MAX_CONNECTIONS: u32 = 1;
 const DEFAULT_MAX_CONNECTIONS: u32 = 10;
 const SQLITE_BUSY_TIMEOUT_MS: u64 = 5_000;
+const SQLITE_WAL_MAX_ATTEMPTS: u32 = 5;
+const SQLITE_WAL_RETRY_DELAY: Duration = Duration::from_secs(1);
+const SQLITE_BUSY: i32 = 5;
+const SQLITE_LOCKED: i32 = 6;
 
 /// Generic database pool type supporting `SQLite`, `PostgreSQL`, and `MySQL`.
 pub type DbPool = sqlx::Pool<sqlx::Any>;
@@ -104,6 +108,37 @@ async fn configure_sqlite_connection(conn: &mut AnyConnection, config: SqliteCon
     Ok(())
 }
 
+async fn enable_sqlite_wal(pool: &DbPool) -> DbResult<()> {
+    enable_sqlite_wal_with_retry(pool, SQLITE_WAL_MAX_ATTEMPTS, SQLITE_WAL_RETRY_DELAY).await
+}
+
+async fn enable_sqlite_wal_with_retry(pool: &DbPool, max_attempts: u32, retry_delay: Duration) -> DbResult<()> {
+    debug_assert!(max_attempts > 0);
+
+    for attempt in 1..=max_attempts {
+        match sqlx::query("PRAGMA journal_mode = WAL").execute(pool).await {
+            Ok(_) => return Ok(()),
+            Err(error) if attempt < max_attempts && sqlite_is_busy_or_locked(&error) => {
+                tokio::time::sleep(retry_delay).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    unreachable!("WAL retry loop always returns on success or final failure")
+}
+
+fn sqlite_is_busy_or_locked(error: &sqlx::Error) -> bool {
+    let sqlx::Error::Database(database_error) = error else {
+        return false;
+    };
+    let Some(code) = database_error.code().and_then(|code| code.parse::<i32>().ok()) else {
+        return false;
+    };
+
+    matches!(code & 0xff, SQLITE_BUSY | SQLITE_LOCKED)
+}
+
 /// Creates a connection pool for the database.
 ///
 /// Initializes a connection pool with sensible defaults:
@@ -156,7 +191,7 @@ pub async fn create_pool_with_sqlite_config(
     }
     let pool = options.connect(&url).await?;
     if sqlite_should_enable_wal(&url) {
-        sqlx::query("PRAGMA journal_mode = WAL").execute(&pool).await?;
+        enable_sqlite_wal(&pool).await?;
     }
 
     // Wrap in Arc for thread-safe sharing across async tasks
@@ -203,6 +238,7 @@ mod tests {
         DEFAULT_SQLITE_JOURNAL_SIZE_LIMIT_BYTES, DEFAULT_SQLITE_MAX_CONNECTIONS, DEFAULT_SQLITE_MMAP_SIZE_BYTES,
         SqliteTempStore,
     };
+    use sqlx::Connection;
 
     #[test]
     fn test_prepare_sqlite_url_without_params() {
@@ -371,6 +407,59 @@ mod tests {
         assert_eq!(journal_size_limit, 131_072);
         assert_eq!(temp_store, 1);
         assert_eq!(mmap_size, 1_048_576);
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_wal_preflight_retries_locked_database() {
+        sqlx::any::install_default_drivers();
+
+        let db_path = std::env::temp_dir().join(format!("wal_retry_{}.db", uuid::Uuid::now_v7()));
+        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+        let mut lock_conn = AnyConnection::connect(&db_url)
+            .await
+            .expect("failed to open lock connection");
+        sqlx::query("CREATE TABLE locked_write (id INTEGER PRIMARY KEY)")
+            .execute(&mut lock_conn)
+            .await
+            .expect("failed to create test table");
+        sqlx::query("BEGIN EXCLUSIVE")
+            .execute(&mut lock_conn)
+            .await
+            .expect("failed to acquire exclusive lock");
+
+        let pool = AnyPoolOptions::new()
+            .max_connections(1)
+            .after_connect(|conn, _meta| {
+                Box::pin(async move {
+                    sqlx::query("PRAGMA busy_timeout = 20").execute(&mut *conn).await?;
+                    Ok(())
+                })
+            })
+            .connect(&db_url)
+            .await
+            .expect("failed to create test pool");
+
+        let wal_pool = pool.clone();
+        let wal_task = tokio::spawn(async move {
+            enable_sqlite_wal_with_retry(&wal_pool, SQLITE_WAL_MAX_ATTEMPTS, Duration::from_millis(50)).await
+        });
+
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        sqlx::query("ROLLBACK")
+            .execute(&mut lock_conn)
+            .await
+            .expect("failed to release exclusive lock");
+
+        wal_task
+            .await
+            .expect("WAL preflight task panicked")
+            .expect("WAL preflight should retry after SQLITE_BUSY");
+
+        let journal_mode: String = sqlx::query_scalar("PRAGMA journal_mode")
+            .fetch_one(&pool)
+            .await
+            .expect("journal_mode query failed");
+        assert_eq!(journal_mode.to_lowercase(), "wal");
     }
 
     #[tokio::test]

--- a/crates/agentic-server-core/src/storage/response.rs
+++ b/crates/agentic-server-core/src/storage/response.rs
@@ -111,13 +111,12 @@ impl ResponseStore {
             let data_str = String::try_from(&any_item)?;
             items_.push((item_id, data_str));
         }
+        let history_item_ids_json = serialize_to_string(&item_ids)?;
+        let metadata_json = String::try_from(metadata)?;
 
         let mut tx = pool.begin().await?;
 
-        item::create_in_tx(&mut tx, items_, None, None).await?;
-
-        let history_item_ids_json = serialize_to_string(&item_ids)?;
-        let metadata_json = String::try_from(metadata)?;
+        item::create_in_tx(&mut tx, items_, None).await?;
 
         response::create_in_tx(
             &mut tx,

--- a/crates/agentic-server-core/tests/storage_integration.rs
+++ b/crates/agentic-server-core/tests/storage_integration.rs
@@ -1,8 +1,11 @@
 mod support;
 
+use agentic_core::config::SqliteConfig;
 use agentic_core::storage::InOutItem;
 use agentic_core::storage::ResponseMetadata;
-use agentic_core::storage::{ConversationStore, ResponseStore};
+use agentic_core::storage::{
+    ConversationStore, ResponseStore, create_pool_with_schema, create_pool_with_schema_and_sqlite_config,
+};
 use agentic_core::types::event::MessageStatus;
 use agentic_core::types::io::{InputItem, InputMessage, InputMessageContent, OutputItem, OutputMessage};
 use std::sync::Arc;
@@ -297,6 +300,172 @@ async fn test_conversation_concurrent_turns() {
 
     let rehydrated = store.rehydrate(&conv_id).await.expect("rehydrate failed");
     assert_eq!(rehydrated.len(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_sqlite_multi_pool_mixed_read_write_concurrency() {
+    let db_path = std::env::temp_dir().join(format!("mixed_rw_{}.db", uuid::Uuid::now_v7()));
+    let db_url = format!("sqlite://{}", db_path.display());
+
+    let writer_pool_a = create_pool_with_schema(Some(&db_url))
+        .await
+        .expect("failed to create writer pool a");
+    let writer_pool_b = create_pool_with_schema(Some(&db_url))
+        .await
+        .expect("failed to create writer pool b");
+    let reader_pool = create_pool_with_schema(Some(&db_url))
+        .await
+        .expect("failed to create reader pool");
+
+    let writer_store_a = ConversationStore::new(Arc::clone(&writer_pool_a));
+    let writer_store_b = ConversationStore::new(writer_pool_b);
+    let reader_store = ConversationStore::new(reader_pool);
+    let conversation = writer_store_a.create().await.expect("create conversation failed");
+    let conv_id = conversation.conversation_id;
+    let metadata = Arc::new(ResponseMetadata::default());
+    let barrier = Arc::new(tokio::sync::Barrier::new(10));
+
+    let spawn_writer = |writer_idx: usize, writer_store: ConversationStore| {
+        let writer_conv_id = conv_id.clone();
+        let writer_metadata = Arc::clone(&metadata);
+        let writer_barrier = Arc::clone(&barrier);
+        tokio::spawn(async move {
+            writer_barrier.wait().await;
+            for idx in 0..50 {
+                writer_store
+                    .persist(
+                        &writer_conv_id,
+                        &format!("resp_lock_writer_{writer_idx}_{idx}"),
+                        None,
+                        vec![create_input_item(&format!("writer {writer_idx} item {idx}"))],
+                        writer_metadata.as_ref(),
+                    )
+                    .await
+                    .map_err(|err| format!("writer {writer_idx} write {idx} failed: {err:?}"))?;
+                tokio::task::yield_now().await;
+            }
+            Ok::<(), String>(())
+        })
+    };
+    let writers = vec![spawn_writer(0, writer_store_a.clone()), spawn_writer(1, writer_store_b)];
+
+    let mut readers = Vec::new();
+    for reader_idx in 0..8 {
+        let reader_store = reader_store.clone();
+        let reader_conv_id = conv_id.clone();
+        let reader_barrier = Arc::clone(&barrier);
+        readers.push(tokio::spawn(async move {
+            reader_barrier.wait().await;
+            for iter in 0..100 {
+                reader_store
+                    .rehydrate(&reader_conv_id)
+                    .await
+                    .map_err(|err| format!("reader {reader_idx} iteration {iter} failed: {err:?}"))?;
+                tokio::task::yield_now().await;
+            }
+            Ok::<(), String>(())
+        }));
+    }
+
+    for writer in writers {
+        writer.await.expect("writer task panicked").expect("writer task failed");
+    }
+    for reader in readers {
+        reader.await.expect("reader task panicked").expect("reader task failed");
+    }
+
+    let final_items = ConversationStore::new(Arc::clone(&writer_pool_a))
+        .rehydrate(&conv_id)
+        .await
+        .expect("final rehydrate failed");
+    assert_eq!(final_items.len(), 100);
+
+    let seqs: Vec<i64> = sqlx::query_scalar("SELECT seq FROM items WHERE conversation_id = ? ORDER BY seq ASC")
+        .bind(&conv_id)
+        .fetch_all(writer_pool_a.as_ref())
+        .await
+        .expect("sequence query failed");
+    assert_eq!(seqs, (0..100).collect::<Vec<_>>());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_sqlite_same_pool_mixed_read_write_concurrency() {
+    let db_path = std::env::temp_dir().join(format!("same_pool_mixed_rw_{}.db", uuid::Uuid::now_v7()));
+    let db_url = format!("sqlite://{}", db_path.display());
+    let sqlite_config = SqliteConfig {
+        max_connections: 4,
+        ..SqliteConfig::default()
+    };
+    let pool = create_pool_with_schema_and_sqlite_config(Some(&db_url), sqlite_config)
+        .await
+        .expect("failed to create pool");
+    assert_eq!(pool.options().get_max_connections(), 4);
+
+    let store = ConversationStore::new(Arc::clone(&pool));
+    let conversation = store.create().await.expect("create conversation failed");
+    let conv_id = conversation.conversation_id;
+    let metadata = Arc::new(ResponseMetadata::default());
+    let barrier = Arc::new(tokio::sync::Barrier::new(10));
+
+    let spawn_writer = |writer_idx: usize| {
+        let writer_store = store.clone();
+        let writer_conv_id = conv_id.clone();
+        let writer_metadata = Arc::clone(&metadata);
+        let writer_barrier = Arc::clone(&barrier);
+        tokio::spawn(async move {
+            writer_barrier.wait().await;
+            for idx in 0..50 {
+                writer_store
+                    .persist(
+                        &writer_conv_id,
+                        &format!("resp_same_pool_writer_{writer_idx}_{idx}"),
+                        None,
+                        vec![create_input_item(&format!("same pool writer {writer_idx} item {idx}"))],
+                        writer_metadata.as_ref(),
+                    )
+                    .await
+                    .map_err(|err| format!("writer {writer_idx} write {idx} failed: {err:?}"))?;
+                tokio::task::yield_now().await;
+            }
+            Ok::<(), String>(())
+        })
+    };
+    let writers = vec![spawn_writer(0), spawn_writer(1)];
+
+    let mut readers = Vec::new();
+    for reader_idx in 0..8 {
+        let reader_store = store.clone();
+        let reader_conv_id = conv_id.clone();
+        let reader_barrier = Arc::clone(&barrier);
+        readers.push(tokio::spawn(async move {
+            reader_barrier.wait().await;
+            for iter in 0..100 {
+                reader_store
+                    .rehydrate(&reader_conv_id)
+                    .await
+                    .map_err(|err| format!("reader {reader_idx} iteration {iter} failed: {err:?}"))?;
+                tokio::task::yield_now().await;
+            }
+            Ok::<(), String>(())
+        }));
+    }
+
+    for writer in writers {
+        writer.await.expect("writer task panicked").expect("writer task failed");
+    }
+    for reader in readers {
+        reader.await.expect("reader task panicked").expect("reader task failed");
+    }
+
+    let final_items = store.rehydrate(&conv_id).await.expect("final rehydrate failed");
+    assert_eq!(final_items.len(), 100);
+
+    let seqs: Vec<i64> = sqlx::query_scalar("SELECT seq FROM items WHERE conversation_id = ? ORDER BY seq ASC")
+        .bind(&conv_id)
+        .fetch_all(pool.as_ref())
+        .await
+        .expect("sequence query failed");
+    assert_eq!(seqs, (0..100).collect::<Vec<_>>());
 }
 
 // Store-level error handling edge cases

--- a/crates/agentic-server/benches/gateway_bench.rs
+++ b/crates/agentic-server/benches/gateway_bench.rs
@@ -159,6 +159,7 @@ async fn spawn_gateway(llm_url: &str) -> (Arc<reqwest::Client>, String) {
         llm_ready_interval_s: 0.1,
         skip_llm_ready_check: false,
         db_url: Some(format!("sqlite://{}", db_path.display())),
+        sqlite: agentic_core::config::SqliteConfig::default(),
     };
 
     let proxy_state = ProxyState::new(config.clone()).unwrap();

--- a/crates/agentic-server/benches/proxy_bench.rs
+++ b/crates/agentic-server/benches/proxy_bench.rs
@@ -31,6 +31,7 @@ fn bench_config(llm_url: &str) -> Config {
         llm_ready_interval_s: 0.1,
         skip_llm_ready_check: false,
         db_url: None,
+        sqlite: agentic_core::config::SqliteConfig::default(),
     }
 }
 

--- a/crates/agentic-server/src/main.rs
+++ b/crates/agentic-server/src/main.rs
@@ -1,6 +1,9 @@
 use clap::{Args, Parser, Subcommand};
 
-use agentic_core::config::{Config, normalize_base_url};
+use agentic_core::config::{
+    Config, DEFAULT_SQLITE_JOURNAL_SIZE_LIMIT_BYTES, DEFAULT_SQLITE_MAX_CONNECTIONS, DEFAULT_SQLITE_MMAP_SIZE_BYTES,
+    SqliteConfig, SqliteTempStore, normalize_base_url,
+};
 use agentic_core::error::Error;
 
 mod server;
@@ -67,15 +70,81 @@ enum Commands {
     },
 }
 
-fn build_config(llm_api_base: String, common: &CommonArgs) -> Config {
-    Config {
+fn parse_env_u64(name: &str, default: u64) -> Result<u64, Error> {
+    parse_env_u64_value(name, std::env::var(name), default)
+}
+
+fn parse_env_u64_value(name: &str, value: Result<String, std::env::VarError>, default: u64) -> Result<u64, Error> {
+    match value {
+        Ok(value) => value
+            .parse::<u64>()
+            .map_err(|e| Error::Config(format!("{name} must be an unsigned integer: {e}"))),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(e) => Err(Error::Config(format!("failed to read {name}: {e}"))),
+    }
+}
+
+fn parse_env_u32(name: &str, default: u32) -> Result<u32, Error> {
+    parse_env_u32_value(name, std::env::var(name), default)
+}
+
+fn parse_env_u32_value(name: &str, value: Result<String, std::env::VarError>, default: u32) -> Result<u32, Error> {
+    match value {
+        Ok(value) => {
+            let parsed = value
+                .parse::<u32>()
+                .map_err(|e| Error::Config(format!("{name} must be a positive integer: {e}")))?;
+            if parsed == 0 {
+                return Err(Error::Config(format!("{name} must be greater than 0")));
+            }
+            Ok(parsed)
+        }
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(e) => Err(Error::Config(format!("failed to read {name}: {e}"))),
+    }
+}
+
+fn parse_env_temp_store() -> Result<SqliteTempStore, Error> {
+    parse_env_temp_store_value(std::env::var("SQLITE_TEMP_STORE"))
+}
+
+fn parse_env_temp_store_value(value: Result<String, std::env::VarError>) -> Result<SqliteTempStore, Error> {
+    match value {
+        Ok(value) => match value.trim().to_ascii_lowercase().as_str() {
+            "default" | "0" => Ok(SqliteTempStore::Default),
+            "file" | "1" => Ok(SqliteTempStore::File),
+            "memory" | "2" => Ok(SqliteTempStore::Memory),
+            _ => Err(Error::Config(
+                "SQLITE_TEMP_STORE must be one of default, file, memory, 0, 1, or 2".to_owned(),
+            )),
+        },
+        Err(std::env::VarError::NotPresent) => Ok(SqliteTempStore::default()),
+        Err(e) => Err(Error::Config(format!("failed to read SQLITE_TEMP_STORE: {e}"))),
+    }
+}
+
+fn sqlite_config_from_env() -> Result<SqliteConfig, Error> {
+    Ok(SqliteConfig {
+        max_connections: parse_env_u32("SQLITE_MAX_CONNECTIONS", DEFAULT_SQLITE_MAX_CONNECTIONS)?,
+        journal_size_limit_bytes: parse_env_u64(
+            "SQLITE_JOURNAL_SIZE_LIMIT_BYTES",
+            DEFAULT_SQLITE_JOURNAL_SIZE_LIMIT_BYTES,
+        )?,
+        temp_store: parse_env_temp_store()?,
+        mmap_size_bytes: parse_env_u64("SQLITE_MMAP_SIZE_BYTES", DEFAULT_SQLITE_MMAP_SIZE_BYTES)?,
+    })
+}
+
+fn build_config(llm_api_base: String, common: &CommonArgs) -> Result<Config, Error> {
+    Ok(Config {
         llm_api_base,
         openai_api_key: common.openai_api_key.clone(),
         llm_ready_timeout_s: common.llm_ready_timeout_s,
         llm_ready_interval_s: common.llm_ready_interval_s,
         skip_llm_ready_check: common.skip_llm_ready_check,
         db_url: Some(common.db_url.clone()),
-    }
+        sqlite: sqlite_config_from_env()?,
+    })
 }
 
 #[tokio::main]
@@ -101,7 +170,7 @@ async fn main() -> Result<(), Error> {
                         .to_owned(),
                 )
             })?;
-            let config = build_config(normalize_base_url(&base), &common);
+            let config = build_config(normalize_base_url(&base), &common)?;
             server::run(config, &common.gateway_host, common.gateway_port).await
         }
         Some(Commands::Serve { model, port, llm_args }) => {
@@ -110,7 +179,7 @@ async fn main() -> Result<(), Error> {
                     "--llm-api-base is only valid in standalone mode; remove it when using `serve`".to_owned(),
                 ));
             }
-            let config = build_config(normalize_base_url(&format!("http://127.0.0.1:{port}")), &common);
+            let config = build_config(normalize_base_url(&format!("http://127.0.0.1:{port}")), &common)?;
             let mut args = vec!["--model".to_owned(), model];
             args.push("--port".to_owned());
             args.push(port.to_string());
@@ -122,9 +191,10 @@ async fn main() -> Result<(), Error> {
 
 #[cfg(test)]
 mod tests {
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
 
-    use super::{Cli, Commands};
+    use super::{Cli, Commands, parse_env_temp_store_value, parse_env_u32_value, parse_env_u64_value};
+    use agentic_core::config::{DEFAULT_SQLITE_MAX_CONNECTIONS, SqliteTempStore};
 
     #[test]
     fn serve_uses_common_args_before_subcommand() {
@@ -149,5 +219,91 @@ mod tests {
             "--skip-llm-ready-check",
         ]);
         assert!(cli.common.skip_llm_ready_check);
+    }
+
+    #[test]
+    fn sqlite_tuning_is_env_only_not_cli() {
+        let mut help = Vec::new();
+        Cli::command().write_long_help(&mut help).expect("render help");
+        let help = String::from_utf8(help).expect("help is utf8");
+
+        assert!(!help.contains("--sqlite-journal-size-limit-bytes"));
+        assert!(!help.contains("--sqlite-max-connections"));
+        assert!(!help.contains("--sqlite-temp-store"));
+        assert!(!help.contains("--sqlite-mmap-size-bytes"));
+
+        assert!(
+            Cli::try_parse_from([
+                "agentic-server",
+                "--llm-api-base",
+                "http://localhost:8000",
+                "--sqlite-temp-store",
+                "memory",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn sqlite_tuning_env_parser_uses_defaults_and_rejects_invalid_values() {
+        assert_eq!(
+            parse_env_u32_value(
+                "SQLITE_MAX_CONNECTIONS",
+                Err(std::env::VarError::NotPresent),
+                DEFAULT_SQLITE_MAX_CONNECTIONS
+            )
+            .expect("default value"),
+            DEFAULT_SQLITE_MAX_CONNECTIONS
+        );
+        assert_eq!(
+            parse_env_u32_value(
+                "SQLITE_MAX_CONNECTIONS",
+                Ok("6".to_owned()),
+                DEFAULT_SQLITE_MAX_CONNECTIONS
+            )
+            .expect("parsed value"),
+            6
+        );
+        assert!(
+            parse_env_u32_value(
+                "SQLITE_MAX_CONNECTIONS",
+                Ok("0".to_owned()),
+                DEFAULT_SQLITE_MAX_CONNECTIONS
+            )
+            .is_err()
+        );
+        assert!(
+            parse_env_u32_value(
+                "SQLITE_MAX_CONNECTIONS",
+                Ok("not-a-number".to_owned()),
+                DEFAULT_SQLITE_MAX_CONNECTIONS
+            )
+            .is_err()
+        );
+
+        assert_eq!(
+            parse_env_u64_value("SQLITE_MMAP_SIZE_BYTES", Err(std::env::VarError::NotPresent), 1_024)
+                .expect("default value"),
+            1_024
+        );
+        assert_eq!(
+            parse_env_u64_value("SQLITE_MMAP_SIZE_BYTES", Ok("4096".to_owned()), 1_024).expect("parsed value"),
+            4_096
+        );
+        assert!(parse_env_u64_value("SQLITE_MMAP_SIZE_BYTES", Ok("not-a-number".to_owned()), 1_024).is_err());
+
+        assert_eq!(
+            parse_env_temp_store_value(Err(std::env::VarError::NotPresent)).expect("default temp store"),
+            SqliteTempStore::Memory
+        );
+        assert_eq!(
+            parse_env_temp_store_value(Ok("file".to_owned())).expect("file temp store"),
+            SqliteTempStore::File
+        );
+        assert_eq!(
+            parse_env_temp_store_value(Ok("2".to_owned())).expect("memory temp store"),
+            SqliteTempStore::Memory
+        );
+        assert!(parse_env_temp_store_value(Ok("invalid".to_owned())).is_err());
     }
 }

--- a/crates/agentic-server/tests/common/mod.rs
+++ b/crates/agentic-server/tests/common/mod.rs
@@ -21,6 +21,7 @@ pub fn test_config(llm_url: &str) -> Config {
         llm_ready_interval_s: 0.1,
         skip_llm_ready_check: false,
         db_url: None,
+        sqlite: agentic_core::config::SqliteConfig::default(),
     }
 }
 


### PR DESCRIPTION
This PR improves SQLite's concurrency behavior so the default local storage path is more robust under realistic read/write workloads.

Even if production deployments eventually standardize on PostgreSQL, this work keeps the storage layer disciplined around short transactions, concurrent access, and deterministic sequence allocation, which are useful invariants for production databases too. SQLite should be as reliable as practical for development, testing, and lightweight deployments while preserving a clear path to PostgreSQL.

## Summary

- Enable SQLite WAL mode for writable file-backed databases and configure connection pragmas for concurrency:
  - `busy_timeout`
  - `foreign_keys`
  - `synchronous=NORMAL`
  - `journal_size_limit`
  - `temp_store`
  - `mmap_size`
- Keep SQLite as the default storage backend and use a small multi-connection pool for file-backed databases.
- Keep in-memory SQLite single-connection to avoid splitting schema/data across private in-memory connections.
- Shorten write transaction windows by moving serialization before `pool.begin()`.
- Compute conversation item sequence ranges inside the insert statement, avoiding a separate pre-write `SELECT MAX(seq)`.
- Add env-only SQLite tuning via:
  - `SQLITE_MAX_CONNECTIONS`, default `4` for file-backed SQLite; in-memory SQLite always uses `1`
  - `SQLITE_JOURNAL_SIZE_LIMIT_BYTES`, default `6144000`
  - `SQLITE_TEMP_STORE`, default `memory`
  - `SQLITE_MMAP_SIZE_BYTES`, default `268435456`
- Ignore SQLite WAL sidecar files in `.gitignore`.

## Test Plan

- Added storage regression coverage with `test_sqlite_multi_pool_mixed_read_write_concurrency`, which opens independent SQLite pools to the same file, runs concurrent readers and writers, asserts no lock errors, and verifies final item count plus gap-free sequence numbers.
- Added same-pool mixed read/write regression coverage with `test_sqlite_same_pool_mixed_read_write_concurrency`, which verifies file-backed SQLite pools can use multiple connections safely.
- Added WAL startup regression coverage with `test_sqlite_wal_preflight_retries_locked_database`, which verifies WAL initialization retries after a transient SQLite locked-database error.
- Added SQLite pool sizing tests for file-backed pool size configuration and the in-memory single-connection override.
- Added SQLite pragma tests for WAL, busy timeout, foreign keys, synchronous mode, journal size limit, temp store, mmap size, and explicit custom tuning values.
- Added server config tests that verify SQLite tuning is env-only, not exposed as CLI flags, and that env parser defaults/invalid values behave correctly.
- Added benchmark coverage with `concurrent_conversation_mixed_read_write`, measuring one writer plus N concurrent readers across independent SQLite pools.

Validated with:

```bash
cargo fmt -- --check
cargo test --locked -p agentic-server-core sqlite_max_connections -- --nocapture
cargo test --locked -p agentic-server-core sqlite_memory_pool_stays_single_connection -- --nocapture
cargo test --locked -p agentic-server-core test_sqlite_multi_pool_mixed_read_write_concurrency -- --nocapture
cargo test --locked -p agentic-server-core test_sqlite_same_pool_mixed_read_write_concurrency -- --nocapture
cargo test --locked -p agentic-server-core test_sqlite_wal_preflight_retries_locked_database -- --nocapture
cargo test --locked -p agentic-server-core storage::pool::tests::test_sqlite_connection_pragmas -- --nocapture
cargo test --locked -p agentic-server sqlite_tuning -- --nocapture
cargo test --locked -p agentic-server-core --bench benches --no-run
cargo clippy --locked --all-targets -- -D warnings
cargo test --locked
```