### PR TITLE
ci: add manual crates release workflow

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -1,0 +1,149 @@
+name: Release crates
+
+run-name: Release crates (${{ inputs.dry_run && 'dry run' || 'publish' }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run packaging and publish checks without uploading crates"
+        required: true
+        type: boolean
+        default: true
+
+concurrency:
+  group: release-crates
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Release crates.io packages
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Verify maintainer permission
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          permission="$(gh api \
+            "repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission" \
+            --jq '.permission')"
+
+          case "$permission" in
+            admin|maintain)
+              echo "${{ github.actor }} has $permission permission"
+              ;;
+            *)
+              echo "::error::${{ github.actor }} has $permission permission; crates releases require admin or maintain permission"
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-release-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-release-${{ runner.os }}-
+            cargo-${{ runner.os }}-
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run tests
+        run: cargo test
+
+      - name: Read release version
+        id: version
+        run: |
+          set -euo pipefail
+          core_version="$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "agentic-server-core") | .version')"
+          server_version="$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "agentic-server") | .version')"
+
+          if [ -z "$core_version" ] || [ "$core_version" = "null" ]; then
+            echo "::error::agentic-server-core package not found in workspace metadata"
+            exit 1
+          fi
+
+          if [ "$core_version" != "$server_version" ]; then
+            echo "::error::agentic-server-core ($core_version) and agentic-server ($server_version) versions differ"
+            exit 1
+          fi
+
+          echo "version=$core_version" >> "$GITHUB_OUTPUT"
+          echo "Release version: $core_version"
+
+      - name: Check published versions
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+
+          if cargo info "agentic-server-core@$version" >/dev/null 2>&1; then
+            echo "::error::agentic-server-core $version is already published"
+            exit 1
+          fi
+
+          if cargo info "agentic-server@$version" >/dev/null 2>&1; then
+            echo "::error::agentic-server $version is already published"
+            exit 1
+          fi
+
+      - name: Dry-run package publication
+        if: inputs.dry_run
+        run: |
+          set -euo pipefail
+          cargo publish --dry-run -p agentic-server-core
+          cargo package -p agentic-server --no-verify
+
+      - name: Publish agentic-server-core
+        if: ${{ !inputs.dry_run }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p agentic-server-core
+
+      - name: Wait for agentic-server-core index
+        if: ${{ !inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+
+          for attempt in {1..30}; do
+            if cargo info "agentic-server-core@$version" >/dev/null 2>&1; then
+              echo "agentic-server-core $version is available in crates.io index"
+              exit 0
+            fi
+
+            echo "Waiting for crates.io index to expose agentic-server-core $version (attempt $attempt/30)"
+            sleep 10
+          done
+
+          echo "::error::agentic-server-core $version was not visible in crates.io index in time"
+          exit 1
+
+      - name: Publish agentic-server
+        if: ${{ !inputs.dry_run }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p agentic-server

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   release:
@@ -93,7 +93,25 @@ jobs:
           fi
 
           echo "version=$core_version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$core_version" >> "$GITHUB_OUTPUT"
+          echo "release_branch=release/v$core_version" >> "$GITHUB_OUTPUT"
           echo "Release version: $core_version"
+
+      - name: Check release refs
+        run: |
+          set -euo pipefail
+          tag="${{ steps.version.outputs.tag }}"
+          release_branch="${{ steps.version.outputs.release_branch }}"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "::error::Tag $tag already exists"
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --heads origin "$release_branch" >/dev/null 2>&1; then
+            echo "::error::Release branch $release_branch already exists"
+            exit 1
+          fi
 
       - name: Check published versions
         run: |
@@ -116,6 +134,9 @@ jobs:
           set -euo pipefail
           cargo publish --dry-run -p agentic-server-core
           cargo package -p agentic-server --no-verify
+          echo "Would create tag ${{ steps.version.outputs.tag }}"
+          echo "Would create branch ${{ steps.version.outputs.release_branch }}"
+          echo "Would create GitHub release ${{ steps.version.outputs.tag }} with generated notes"
 
       - name: Publish agentic-server-core
         if: ${{ !inputs.dry_run }}
@@ -147,3 +168,29 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish -p agentic-server
+
+      - name: Create release refs
+        if: ${{ !inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.version.outputs.tag }}"
+          release_branch="${{ steps.version.outputs.release_branch }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$tag" "$GITHUB_SHA" -m "$tag"
+          git push origin "$tag"
+          git push origin "$GITHUB_SHA:refs/heads/$release_branch"
+
+      - name: Create GitHub release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.version.outputs.tag }}"
+          gh release create "$tag" \
+            --target "$GITHUB_SHA" \
+            --title "$tag" \
+            --generate-notes

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -134,6 +134,7 @@ jobs:
           set -euo pipefail
           cargo publish --dry-run -p agentic-server-core
           cargo package -p agentic-server --no-verify
+          echo "Would create empty chore release commit: chore: release ${{ steps.version.outputs.tag }}"
           echo "Would create tag ${{ steps.version.outputs.tag }}"
           echo "Would create branch ${{ steps.version.outputs.release_branch }}"
           echo "Would create GitHub release ${{ steps.version.outputs.tag }} with generated notes"
@@ -179,9 +180,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git tag -a "$tag" "$GITHUB_SHA" -m "$tag"
+          git commit --allow-empty -s -m "chore: release $tag"
+          release_commit="$(git rev-parse HEAD)"
+
+          git tag -a "$tag" "$release_commit" -m "$tag"
           git push origin "$tag"
-          git push origin "$GITHUB_SHA:refs/heads/$release_branch"
+          git push origin "$release_commit:refs/heads/$release_branch"
 
       - name: Create GitHub release
         if: ${{ !inputs.dry_run }}
@@ -191,6 +195,5 @@ jobs:
           set -euo pipefail
           tag="${{ steps.version.outputs.tag }}"
           gh release create "$tag" \
-            --target "$GITHUB_SHA" \
             --title "$tag" \
             --generate-notes

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -94,7 +94,7 @@ jobs:
 
           echo "version=$core_version" >> "$GITHUB_OUTPUT"
           echo "tag=v$core_version" >> "$GITHUB_OUTPUT"
-          echo "release_branch=release/v$core_version" >> "$GITHUB_OUTPUT"
+          echo "release_branch=releases/v$core_version" >> "$GITHUB_OUTPUT"
           echo "Release version: $core_version"
 
       - name: Check release refs
@@ -134,7 +134,6 @@ jobs:
           set -euo pipefail
           cargo publish --dry-run -p agentic-server-core
           cargo package -p agentic-server --no-verify
-          echo "Would create empty chore release commit: chore: release ${{ steps.version.outputs.tag }}"
           echo "Would create tag ${{ steps.version.outputs.tag }}"
           echo "Would create branch ${{ steps.version.outputs.release_branch }}"
           echo "Would create GitHub release ${{ steps.version.outputs.tag }} with generated notes"
@@ -180,12 +179,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git commit --allow-empty -s -m "chore: release $tag"
-          release_commit="$(git rev-parse HEAD)"
-
-          git tag -a "$tag" "$release_commit" -m "$tag"
+          git tag -a "$tag" "$GITHUB_SHA" -m "$tag"
           git push origin "$tag"
-          git push origin "$release_commit:refs/heads/$release_branch"
+          git push origin "$GITHUB_SHA:refs/heads/$release_branch"
 
       - name: Create GitHub release
         if: ${{ !inputs.dry_run }}
@@ -195,5 +191,6 @@ jobs:
           set -euo pipefail
           tag="${{ steps.version.outputs.tag }}"
           gh release create "$tag" \
+            --target "$GITHUB_SHA" \
             --title "$tag" \
             --generate-notes


### PR DESCRIPTION
## Summary
- add a manual `workflow_dispatch` workflow for crates.io releases
- default the button to dry-run mode and require an explicit toggle for real publishing
- gate the workflow to `main` and require the actor to have `admin` or `maintain` repo permission
- publish in the proven order: `agentic-server-core` first, then `agentic-server` after the crates.io index sees core
- follow the vLLM release-ref pattern by creating `releases/vX.Y.Z`, tagging `vX.Y.Z`, and generating GitHub Release notes from the published commit
- scope `CARGO_REGISTRY_TOKEN` only to the actual publish steps

## Test Plan
- `SKIP=no-commit-to-branch uvx pre-commit run --files .github/workflows/release-crates.yml`
- `git diff --check -- .github/workflows/release-crates.yml`
