### PR TITLE
feat: add Anthropic Messages gateway proxy

### DIFF
--- a/crates/agentic-server-core/src/proxy.rs
+++ b/crates/agentic-server-core/src/proxy.rs
@@ -32,10 +32,18 @@ fn is_request_drop(name: &str) -> bool {
     is_hop_by_hop(name) || REQUEST_DROP_EXTRA.iter().any(|h| h.eq_ignore_ascii_case(name))
 }
 
+/// Raw request data forwarded to the default Responses upstream endpoint.
 pub struct ProxyRequest {
     pub headers: HeaderMap,
     pub body: Bytes,
     pub query: Option<String>,
+}
+
+/// Authentication fallback used when proxying a request to an upstream API.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProxyAuth {
+    OpenAiBearer,
+    Anthropic,
 }
 
 pub enum ProxyBody {
@@ -84,7 +92,7 @@ impl ProxyState {
     }
 }
 
-fn filter_request_headers(headers: &HeaderMap, config: &Config) -> reqwest::header::HeaderMap {
+fn filter_request_headers(headers: &HeaderMap, config: &Config, auth: ProxyAuth) -> reqwest::header::HeaderMap {
     let mut out = reqwest::header::HeaderMap::new();
     for (name, value) in headers {
         if is_request_drop(name.as_str()) {
@@ -98,12 +106,20 @@ fn filter_request_headers(headers: &HeaderMap, config: &Config) -> reqwest::head
     }
 
     let has_auth = out.contains_key(reqwest::header::AUTHORIZATION);
-    if !has_auth {
+    let has_api_key = out.contains_key("x-api-key");
+    if !has_auth && !has_api_key {
         if let Some(key) = config.openai_api_key.as_deref() {
             let trimmed = key.trim();
             if !trimmed.is_empty() {
-                if let Ok(v) = reqwest::header::HeaderValue::from_str(&format!("Bearer {trimmed}")) {
-                    out.insert(reqwest::header::AUTHORIZATION, v);
+                let (name, value) = match auth {
+                    ProxyAuth::OpenAiBearer => (reqwest::header::AUTHORIZATION, format!("Bearer {trimmed}")),
+                    ProxyAuth::Anthropic => (
+                        reqwest::header::HeaderName::from_static("x-api-key"),
+                        trimmed.to_owned(),
+                    ),
+                };
+                if let Ok(v) = reqwest::header::HeaderValue::from_str(&value) {
+                    out.insert(name, v);
                 }
             }
         }
@@ -159,7 +175,7 @@ pub fn error_response(status: StatusCode, code: &str, message: &str) -> ProxyRes
 /// Uses the non-streaming client; the response body is returned as a full
 /// [`ProxyBody::Full`] payload.
 pub async fn proxy_get(path: &str, request_headers: &HeaderMap, state: &ProxyState) -> ProxyResponse {
-    let llm_headers = filter_request_headers(request_headers, &state.config);
+    let llm_headers = filter_request_headers(request_headers, &state.config, ProxyAuth::OpenAiBearer);
     let base = state.config.llm_api_base.trim_end_matches('/');
     let url = format!("{base}/{}", path.trim_start_matches('/'));
 
@@ -195,16 +211,27 @@ pub async fn proxy_get(path: &str, request_headers: &HeaderMap, state: &ProxySta
     }
 }
 
+/// Proxy a request to the default `/v1/responses` upstream endpoint.
 pub async fn proxy_request(request: ProxyRequest, state: &ProxyState) -> ProxyResponse {
+    proxy_request_with_path(request, "/v1/responses", ProxyAuth::OpenAiBearer, state).await
+}
+
+/// Proxy a raw request to a selected upstream path.
+pub async fn proxy_request_with_path(
+    request: ProxyRequest,
+    path: &str,
+    auth: ProxyAuth,
+    state: &ProxyState,
+) -> ProxyResponse {
     let is_streaming = serde_json::from_slice::<Value>(&request.body)
         .ok()
         .and_then(|v| v.get("stream")?.as_bool())
         .unwrap_or(false);
 
-    let llm_headers = filter_request_headers(&request.headers, &state.config);
+    let llm_headers = filter_request_headers(&request.headers, &state.config, auth);
 
     let base = state.config.llm_api_base.trim_end_matches('/');
-    let mut url = format!("{base}/v1/responses");
+    let mut url = format!("{base}/{}", path.trim_start_matches('/'));
     if let Some(q) = &request.query {
         url.push('?');
         url.push_str(q);
@@ -311,6 +338,15 @@ mod tests {
     }
 
     #[test]
+    fn proxy_request_retains_legacy_construction_shape() {
+        let _request = ProxyRequest {
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            query: None,
+        };
+    }
+
+    #[test]
     fn filter_request_headers_strips_hop_by_hop() {
         let mut headers = HeaderMap::new();
         headers.insert("content-type", "application/json".parse().unwrap());
@@ -319,7 +355,7 @@ mod tests {
         headers.insert("x-custom", "value".parse().unwrap());
 
         let config = test_config_no_key();
-        let filtered = filter_request_headers(&headers, &config);
+        let filtered = filter_request_headers(&headers, &config, ProxyAuth::OpenAiBearer);
 
         assert!(filtered.contains_key("content-type"));
         assert!(filtered.contains_key("x-custom"));
@@ -335,7 +371,7 @@ mod tests {
         headers.insert("accept", "*/*".parse().unwrap());
 
         let config = test_config_no_key();
-        let filtered = filter_request_headers(&headers, &config);
+        let filtered = filter_request_headers(&headers, &config, ProxyAuth::OpenAiBearer);
 
         assert!(!filtered.contains_key("host"));
         assert!(!filtered.contains_key("content-length"));
@@ -346,7 +382,7 @@ mod tests {
     fn auth_injected_when_no_client_auth() {
         let headers = HeaderMap::new();
         let config = test_config();
-        let filtered = filter_request_headers(&headers, &config);
+        let filtered = filter_request_headers(&headers, &config, ProxyAuth::OpenAiBearer);
 
         assert_eq!(
             filtered.get("authorization").unwrap().to_str().unwrap(),
@@ -360,12 +396,31 @@ mod tests {
         headers.insert("authorization", "Bearer client-token".parse().unwrap());
 
         let config = test_config();
-        let filtered = filter_request_headers(&headers, &config);
+        let filtered = filter_request_headers(&headers, &config, ProxyAuth::OpenAiBearer);
 
         assert_eq!(
             filtered.get("authorization").unwrap().to_str().unwrap(),
             "Bearer client-token"
         );
+    }
+
+    #[test]
+    fn anthropic_auth_preserves_client_api_key() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-api-key", "client-anthropic-key".parse().unwrap());
+
+        let filtered = filter_request_headers(&headers, &test_config(), ProxyAuth::Anthropic);
+
+        assert_eq!(filtered.get("x-api-key").unwrap(), "client-anthropic-key");
+        assert!(!filtered.contains_key("authorization"));
+    }
+
+    #[test]
+    fn anthropic_auth_uses_configured_key_as_api_key_fallback() {
+        let filtered = filter_request_headers(&HeaderMap::new(), &test_config(), ProxyAuth::Anthropic);
+
+        assert_eq!(filtered.get("x-api-key").unwrap(), "test-key");
+        assert!(!filtered.contains_key("authorization"));
     }
 
     #[test]
@@ -375,7 +430,7 @@ mod tests {
             openai_api_key: Some("  ".to_owned()),
             ..test_config()
         };
-        let filtered = filter_request_headers(&headers, &config);
+        let filtered = filter_request_headers(&headers, &config, ProxyAuth::OpenAiBearer);
 
         assert!(!filtered.contains_key("authorization"));
     }
@@ -384,7 +439,7 @@ mod tests {
     fn no_auth_injected_when_key_none() {
         let headers = HeaderMap::new();
         let config = test_config_no_key();
-        let filtered = filter_request_headers(&headers, &config);
+        let filtered = filter_request_headers(&headers, &config, ProxyAuth::OpenAiBearer);
 
         assert!(!filtered.contains_key("authorization"));
     }

--- a/crates/agentic-server-core/src/proxy.rs
+++ b/crates/agentic-server-core/src/proxy.rs
@@ -152,14 +152,28 @@ fn is_sse_content_type(headers: &reqwest::header::HeaderMap) -> bool {
 
 #[must_use]
 pub fn error_response(status: StatusCode, code: &str, message: &str) -> ProxyResponse {
-    let body = serde_json::json!({
-        "error": {
-            "message": message,
-            "type": "api_error",
-            "param": null,
-            "code": code,
-        }
-    });
+    error_response_for_auth(status, code, message, ProxyAuth::OpenAiBearer)
+}
+
+#[must_use]
+pub fn error_response_for_auth(status: StatusCode, code: &str, message: &str, auth: ProxyAuth) -> ProxyResponse {
+    let body = match auth {
+        ProxyAuth::OpenAiBearer => serde_json::json!({
+            "error": {
+                "message": message,
+                "type": "api_error",
+                "param": null,
+                "code": code,
+            }
+        }),
+        ProxyAuth::Anthropic => serde_json::json!({
+            "type": "error",
+            "error": {
+                "type": "api_error",
+                "message": message,
+            }
+        }),
+    };
     let mut headers = HeaderMap::new();
     headers.insert("content-type", HeaderValue::from_static("application/json"));
     ProxyResponse {
@@ -247,11 +261,11 @@ pub async fn proxy_request_with_path(
         Ok(r) => r,
         Err(e) if e.is_timeout() => {
             warn!("LLM request timed out: {e}");
-            return error_response(StatusCode::GATEWAY_TIMEOUT, "llm_timeout", "LLM timeout");
+            return error_response_for_auth(StatusCode::GATEWAY_TIMEOUT, "llm_timeout", "LLM timeout", auth);
         }
         Err(e) => {
             warn!("LLM request failed: {e}");
-            return error_response(StatusCode::BAD_GATEWAY, "llm_unavailable", "LLM unavailable");
+            return error_response_for_auth(StatusCode::BAD_GATEWAY, "llm_unavailable", "LLM unavailable", auth);
         }
     };
 
@@ -274,10 +288,11 @@ pub async fn proxy_request_with_path(
         Ok(b) => b,
         Err(e) => {
             warn!("failed to read LLM response body: {e}");
-            return error_response(
+            return error_response_for_auth(
                 StatusCode::BAD_GATEWAY,
                 "llm_unavailable",
                 "Failed to read LLM response",
+                auth,
             );
         }
     };

--- a/crates/agentic-server/src/app.rs
+++ b/crates/agentic-server/src/app.rs
@@ -9,7 +9,7 @@ use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use agentic_core::executor::ExecutionContext;
 use agentic_core::proxy::ProxyState;
 
-use crate::handler::{conversations, health, models, ready, responses, responses_ws};
+use crate::handler::{conversations, count_tokens, health, messages, models, ready, responses, responses_ws};
 
 /// Server-level configuration read from environment variables.
 pub struct ServerConfig {
@@ -75,6 +75,8 @@ pub fn build_router(state: AppState, server_config: &ServerConfig) -> Router {
         .route("/ready", get(ready))
         .route("/v1/conversations", post(conversations))
         .route("/v1/models", get(models))
+        .route("/v1/messages", post(messages))
+        .route("/v1/messages/count_tokens", post(count_tokens))
         .route("/v1/responses", post(responses).get(responses_ws))
         .layer(server_config.cors_layer())
         .with_state(state)

--- a/crates/agentic-server/src/handler/common.rs
+++ b/crates/agentic-server/src/handler/common.rs
@@ -7,7 +7,7 @@ use http::StatusCode;
 use tracing::warn;
 
 use agentic_core::executor::{BoxStream, ExecutorError};
-use agentic_core::proxy::{ProxyBody, ProxyResponse, error_response};
+use agentic_core::proxy::{ProxyAuth, ProxyBody, ProxyResponse, error_response_for_auth};
 use agentic_core::types::request_response::RequestPayload;
 
 pub(super) const MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
@@ -40,11 +40,16 @@ pub fn executor_error_response(err: ExecutorError) -> Response {
 }
 
 pub(super) async fn read_bytes(body: Body) -> Result<Bytes, Response> {
+    read_bytes_with_auth(body, ProxyAuth::OpenAiBearer).await
+}
+
+pub(super) async fn read_bytes_with_auth(body: Body, auth: ProxyAuth) -> Result<Bytes, Response> {
     axum::body::to_bytes(body, MAX_BODY_SIZE).await.map_err(|_| {
-        convert_response(error_response(
+        convert_response(error_response_for_auth(
             StatusCode::PAYLOAD_TOO_LARGE,
             "body_too_large",
             "request body too large",
+            auth,
         ))
     })
 }

--- a/crates/agentic-server/src/handler/http/messages.rs
+++ b/crates/agentic-server/src/handler/http/messages.rs
@@ -4,12 +4,12 @@ use bytes::Bytes;
 
 use agentic_core::proxy::{ProxyAuth, ProxyRequest, proxy_request_with_path};
 
-use super::super::common::{convert_response, read_bytes};
+use super::super::common::{convert_response, read_bytes_with_auth};
 use crate::app::AppState;
 
 async fn proxy_messages(state: &AppState, request: Request, path: &'static str) -> Response {
     let (parts, body) = request.into_parts();
-    let body: Bytes = match read_bytes(body).await {
+    let body: Bytes = match read_bytes_with_auth(body, ProxyAuth::Anthropic).await {
         Ok(body) => body,
         Err(response) => return response,
     };

--- a/crates/agentic-server/src/handler/http/messages.rs
+++ b/crates/agentic-server/src/handler/http/messages.rs
@@ -1,0 +1,38 @@
+use axum::extract::{Request, State};
+use axum::response::Response;
+use bytes::Bytes;
+
+use agentic_core::proxy::{ProxyAuth, ProxyRequest, proxy_request_with_path};
+
+use super::super::common::{convert_response, read_bytes};
+use crate::app::AppState;
+
+async fn proxy_messages(state: &AppState, request: Request, path: &'static str) -> Response {
+    let (parts, body) = request.into_parts();
+    let body: Bytes = match read_bytes(body).await {
+        Ok(body) => body,
+        Err(response) => return response,
+    };
+
+    convert_response(
+        proxy_request_with_path(
+            ProxyRequest {
+                headers: parts.headers,
+                body,
+                query: parts.uri.query().map(str::to_owned),
+            },
+            path,
+            ProxyAuth::Anthropic,
+            &state.proxy_state,
+        )
+        .await,
+    )
+}
+
+pub async fn messages(State(state): State<AppState>, request: Request) -> Response {
+    proxy_messages(&state, request, "/v1/messages").await
+}
+
+pub async fn count_tokens(State(state): State<AppState>, request: Request) -> Response {
+    proxy_messages(&state, request, "/v1/messages/count_tokens").await
+}

--- a/crates/agentic-server/src/handler/http/mod.rs
+++ b/crates/agentic-server/src/handler/http/mod.rs
@@ -1,7 +1,9 @@
 mod conversations;
+mod messages;
 mod models;
 mod responses;
 
 pub use conversations::conversations;
+pub use messages::{count_tokens, messages};
 pub use models::{health, models, ready};
 pub use responses::responses;

--- a/crates/agentic-server/src/handler/mod.rs
+++ b/crates/agentic-server/src/handler/mod.rs
@@ -3,5 +3,5 @@ pub mod http;
 pub mod websocket;
 
 pub use common::{convert_response, executor_error_response};
-pub use http::{conversations, health, models, ready, responses};
+pub use http::{conversations, count_tokens, health, messages, models, ready, responses};
 pub use websocket::responses_ws;

--- a/crates/agentic-server/tests/messages_test.rs
+++ b/crates/agentic-server/tests/messages_test.rs
@@ -75,11 +75,11 @@ async fn spawn_recording_upstream(
 }
 
 #[tokio::test]
-async fn messages_forwards_raw_body_query_and_claude_headers() {
+async fn messages_forwards_raw_body_query_headers_and_client_tools() {
     let (llm_url, requests, _upstream) =
         spawn_recording_upstream(StatusCode::OK, "application/json", r#"{"id":"msg_1"}"#).await;
     let (gateway_url, _gateway) = spawn_gateway(test_state(&test_config(&llm_url))).await;
-    let body = br#"{"model":"test","tools":[{"type":"web_search_20250305","name":"web_search"}],"stream":false,"new_field":{"keep":true}}"#;
+    let body = br#"{"model":"test","tools":[{"name":"WebSearch","description":"Search the web","input_schema":{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}},{"name":"WebFetch","description":"Fetch a web page","input_schema":{"type":"object","properties":{"url":{"type":"string"}},"required":["url"]}}],"stream":false,"new_field":{"keep":true}}"#;
 
     let response = reqwest::Client::new()
         .post(format!("{gateway_url}/v1/messages?beta=true"))

--- a/crates/agentic-server/tests/messages_test.rs
+++ b/crates/agentic-server/tests/messages_test.rs
@@ -1,0 +1,174 @@
+#[allow(dead_code)]
+mod common;
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Bytes;
+use axum::extract::OriginalUri;
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use http::{HeaderMap, StatusCode};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+
+use common::{spawn_gateway, test_config, test_state};
+
+#[derive(Clone, Debug)]
+struct RecordedRequest {
+    uri: String,
+    headers: HeaderMap,
+    body: Bytes,
+}
+
+async fn spawn_recording_upstream(
+    status: StatusCode,
+    content_type: &'static str,
+    response_body: &'static str,
+) -> (String, Arc<Mutex<Vec<RecordedRequest>>>, tokio::task::JoinHandle<()>) {
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let route_requests = Arc::clone(&requests);
+    let count_tokens_requests = Arc::clone(&requests);
+    let app = Router::new()
+        .route(
+            "/v1/messages",
+            post(move |OriginalUri(uri), headers: HeaderMap, body: Bytes| {
+                let route_requests = Arc::clone(&route_requests);
+                async move {
+                    route_requests.lock().await.push(RecordedRequest {
+                        uri: uri.to_string(),
+                        headers,
+                        body,
+                    });
+                    Response::builder()
+                        .status(status)
+                        .header("content-type", content_type)
+                        .body(axum::body::Body::from(response_body))
+                        .unwrap()
+                        .into_response()
+                }
+            }),
+        )
+        .route(
+            "/v1/messages/count_tokens",
+            post(move |OriginalUri(uri), headers: HeaderMap, body: Bytes| {
+                let route_requests = Arc::clone(&count_tokens_requests);
+                async move {
+                    route_requests.lock().await.push(RecordedRequest {
+                        uri: uri.to_string(),
+                        headers,
+                        body,
+                    });
+                    Response::builder()
+                        .status(status)
+                        .header("content-type", content_type)
+                        .body(axum::body::Body::from(response_body))
+                        .unwrap()
+                        .into_response()
+                }
+            }),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (format!("http://{addr}"), requests, handle)
+}
+
+#[tokio::test]
+async fn messages_forwards_raw_body_query_and_claude_headers() {
+    let (llm_url, requests, _upstream) =
+        spawn_recording_upstream(StatusCode::OK, "application/json", r#"{"id":"msg_1"}"#).await;
+    let (gateway_url, _gateway) = spawn_gateway(test_state(&test_config(&llm_url))).await;
+    let body = br#"{"model":"test","tools":[{"type":"web_search_20250305","name":"web_search"}],"stream":false,"new_field":{"keep":true}}"#;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/messages?beta=true"))
+        .header("anthropic-version", "2023-06-01")
+        .header("anthropic-beta", "web-search-2025-03-05")
+        .header("x-claude-code-session-id", "session-1")
+        .header("x-claude-code-agent-id", "agent-1")
+        .header("x-api-key", "anthropic-key")
+        .header("connection", "keep-alive")
+        .header("host", "gateway.invalid")
+        .body(body.to_vec())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.text().await.unwrap(), r#"{"id":"msg_1"}"#);
+    let requests = requests.lock().await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].uri, "/v1/messages?beta=true");
+    assert_eq!(requests[0].body.as_ref(), body);
+    assert_eq!(requests[0].headers["anthropic-version"], "2023-06-01");
+    assert_eq!(requests[0].headers["anthropic-beta"], "web-search-2025-03-05");
+    assert_eq!(requests[0].headers["x-claude-code-session-id"], "session-1");
+    assert_eq!(requests[0].headers["x-claude-code-agent-id"], "agent-1");
+    assert_eq!(requests[0].headers["x-api-key"], "anthropic-key");
+    assert!(!requests[0].headers.contains_key("connection"));
+    assert_ne!(
+        requests[0].headers.get("host").and_then(|v| v.to_str().ok()),
+        Some("gateway.invalid")
+    );
+}
+
+#[tokio::test]
+async fn messages_forwards_sse_bytes_unchanged() {
+    let sse = "event: message_start\ndata: {\"type\":\"message_start\"}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
+    let (llm_url, _requests, _upstream) = spawn_recording_upstream(StatusCode::OK, "text/event-stream", sse).await;
+    let (gateway_url, _gateway) = spawn_gateway(test_state(&test_config(&llm_url))).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/messages"))
+        .body(r#"{"model":"test","stream":true}"#)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()["content-type"], "text/event-stream");
+    assert_eq!(response.bytes().await.unwrap().as_ref(), sse.as_bytes());
+}
+
+#[tokio::test]
+async fn messages_count_tokens_uses_matching_upstream_path() {
+    let (llm_url, requests, _upstream) =
+        spawn_recording_upstream(StatusCode::OK, "application/json", r#"{"input_tokens":3}"#).await;
+    let (gateway_url, _gateway) = spawn_gateway(test_state(&test_config(&llm_url))).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/messages/count_tokens"))
+        .body(r#"{"model":"test","messages":[]}"#)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.text().await.unwrap(), r#"{"input_tokens":3}"#);
+    assert_eq!(requests.lock().await[0].uri, "/v1/messages/count_tokens");
+}
+
+#[tokio::test]
+async fn messages_preserves_upstream_error_status_and_body() {
+    let (llm_url, _requests, _upstream) = spawn_recording_upstream(
+        StatusCode::BAD_REQUEST,
+        "application/json",
+        r#"{"type":"error","error":{"type":"invalid_request_error","message":"bad"}}"#,
+    )
+    .await;
+    let (gateway_url, _gateway) = spawn_gateway(test_state(&test_config(&llm_url))).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/messages"))
+        .body("{}")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.text().await.unwrap(),
+        r#"{"type":"error","error":{"type":"invalid_request_error","message":"bad"}}"#
+    );
+}

--- a/crates/agentic-server/tests/messages_test.rs
+++ b/crates/agentic-server/tests/messages_test.rs
@@ -195,3 +195,31 @@ async fn messages_preserves_upstream_error_status_and_body() {
         r#"{"type":"error","error":{"type":"invalid_request_error","message":"bad"}}"#
     );
 }
+
+#[tokio::test]
+async fn messages_returns_anthropic_error_for_unreachable_upstream() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let dead_addr = listener.local_addr().unwrap();
+    drop(listener);
+    let (gateway_url, _gateway) = spawn_gateway(test_state(&test_config(&format!("http://{dead_addr}")))).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/messages"))
+        .body("{}")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    let body: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(
+        body,
+        serde_json::json!({
+            "type": "error",
+            "error": {
+                "type": "api_error",
+                "message": "LLM unavailable",
+            },
+        })
+    );
+}

--- a/crates/agentic-server/tests/messages_test.rs
+++ b/crates/agentic-server/tests/messages_test.rs
@@ -75,7 +75,7 @@ async fn spawn_recording_upstream(
 }
 
 #[tokio::test]
-async fn messages_forwards_raw_body_query_headers_and_client_tools() {
+async fn messages_forwards_raw_body_query_headers_and_open_beta_list() {
     let (llm_url, requests, _upstream) =
         spawn_recording_upstream(StatusCode::OK, "application/json", r#"{"id":"msg_1"}"#).await;
     let (gateway_url, _gateway) = spawn_gateway(test_state(&test_config(&llm_url))).await;
@@ -84,7 +84,7 @@ async fn messages_forwards_raw_body_query_headers_and_client_tools() {
     let response = reqwest::Client::new()
         .post(format!("{gateway_url}/v1/messages?beta=true"))
         .header("anthropic-version", "2023-06-01")
-        .header("anthropic-beta", "web-search-2025-03-05")
+        .header("anthropic-beta", "future-beta-unknown,web-search-2025-03-05")
         .header("x-claude-code-session-id", "session-1")
         .header("x-claude-code-agent-id", "agent-1")
         .header("x-api-key", "anthropic-key")
@@ -102,7 +102,10 @@ async fn messages_forwards_raw_body_query_headers_and_client_tools() {
     assert_eq!(requests[0].uri, "/v1/messages?beta=true");
     assert_eq!(requests[0].body.as_ref(), body);
     assert_eq!(requests[0].headers["anthropic-version"], "2023-06-01");
-    assert_eq!(requests[0].headers["anthropic-beta"], "web-search-2025-03-05");
+    assert_eq!(
+        requests[0].headers["anthropic-beta"],
+        "future-beta-unknown,web-search-2025-03-05"
+    );
     assert_eq!(requests[0].headers["x-claude-code-session-id"], "session-1");
     assert_eq!(requests[0].headers["x-claude-code-agent-id"], "agent-1");
     assert_eq!(requests[0].headers["x-api-key"], "anthropic-key");
@@ -111,6 +114,26 @@ async fn messages_forwards_raw_body_query_headers_and_client_tools() {
         requests[0].headers.get("host").and_then(|v| v.to_str().ok()),
         Some("gateway.invalid")
     );
+}
+
+#[tokio::test]
+async fn messages_forwards_system_attribution_blocks_verbatim() {
+    let (llm_url, requests, _upstream) =
+        spawn_recording_upstream(StatusCode::OK, "application/json", r#"{"id":"msg_system"}"#).await;
+    let (gateway_url, _gateway) = spawn_gateway(test_state(&test_config(&llm_url))).await;
+    let body = br#"{"model":"test","system":[{"type":"text","text":"<attribution>session-1</attribution>"},{"type":"text","text":"You are helpful."}],"messages":[{"role":"user","content":"hello"}],"stream":false}"#;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/messages"))
+        .body(body.to_vec())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let requests = requests.lock().await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].body.as_ref(), body);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add transparent Anthropic Messages proxy routes for `/v1/messages` and `/v1/messages/count_tokens`
- preserve raw request bodies, query parameters, Anthropic/Claude Code headers, upstream statuses, JSON responses, SSE streams, and error bodies
- keep the existing Responses proxy API compatible while adding a path-aware internal proxy helper
- add recording-upstream integration coverage using Claude Code-style client-owned `WebSearch`/`WebFetch` tools and arbitrary request fields
- cover the protocol-contract requirements tracked in issue #114: verbatim block-first `system` forwarding, open-list `anthropic-beta` forwarding, and unchanged `anthropic-version`

## Test Plan

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p agentic-server --test messages_test`
- `cargo test -p agentic-server`
- `git diff --check`

PR #98 provides the design and live-spike evidence for the follow-up Phase 2 server-side tool loop: gateway tools must be injected only into upstream vLLM requests, executed inside Agentic API, and hidden from Claude Code. This PR intentionally remains the transparent proxy floor; no gateway-owned web-search execution is included.