### PR TITLE
ci: allow targeting crates release refs

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -10,6 +10,10 @@ on:
         required: true
         type: boolean
         default: true
+      target_ref:
+        description: "Git ref to release, such as a commit SHA or releases/vX.Y.Z branch; defaults to selected main commit"
+        required: false
+        type: string
 
 concurrency:
   group: release-crates
@@ -45,6 +49,17 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.target_ref || github.sha }}
+
+      - name: Resolve release target
+        id: target
+        run: |
+          set -euo pipefail
+          target_sha="$(git rev-parse HEAD)"
+
+          echo "sha=$target_sha" >> "$GITHUB_OUTPUT"
+          echo "Release target: $target_sha"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
@@ -102,14 +117,17 @@ jobs:
           set -euo pipefail
           tag="${{ steps.version.outputs.tag }}"
           release_branch="${{ steps.version.outputs.release_branch }}"
+          target_sha="${{ steps.target.outputs.sha }}"
 
           if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
             echo "::error::Tag $tag already exists"
             exit 1
           fi
 
-          if git ls-remote --exit-code --heads origin "$release_branch" >/dev/null 2>&1; then
-            echo "::error::Release branch $release_branch already exists"
+          existing_branch_sha="$(git ls-remote --heads origin "refs/heads/$release_branch" | awk '{print $1}')"
+
+          if [ -n "$existing_branch_sha" ] && [ "$existing_branch_sha" != "$target_sha" ]; then
+            echo "::error::Release branch $release_branch already exists at $existing_branch_sha, not target $target_sha"
             exit 1
           fi
 
@@ -134,6 +152,7 @@ jobs:
           set -euo pipefail
           cargo publish --dry-run -p agentic-server-core
           cargo package -p agentic-server --no-verify
+          echo "Would release commit ${{ steps.target.outputs.sha }}"
           echo "Would create tag ${{ steps.version.outputs.tag }}"
           echo "Would create branch ${{ steps.version.outputs.release_branch }}"
           echo "Would create GitHub release ${{ steps.version.outputs.tag }} with generated notes"
@@ -175,13 +194,14 @@ jobs:
           set -euo pipefail
           tag="${{ steps.version.outputs.tag }}"
           release_branch="${{ steps.version.outputs.release_branch }}"
+          target_sha="${{ steps.target.outputs.sha }}"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git tag -a "$tag" "$GITHUB_SHA" -m "$tag"
+          git tag -a "$tag" "$target_sha" -m "$tag"
           git push origin "$tag"
-          git push origin "$GITHUB_SHA:refs/heads/$release_branch"
+          git push origin "$target_sha:refs/heads/$release_branch"
 
       - name: Create GitHub release
         if: ${{ !inputs.dry_run }}
@@ -190,7 +210,8 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ steps.version.outputs.tag }}"
+          target_sha="${{ steps.target.outputs.sha }}"
           gh release create "$tag" \
-            --target "$GITHUB_SHA" \
+            --target "$target_sha" \
             --title "$tag" \
             --generate-notes


### PR DESCRIPTION
## Summary
- add an optional `target_ref` input to the manual crates release workflow
- resolve the checked-out release target once and use that SHA for package checks, publishing, tags, release branches, and GitHub Release notes
- allow an existing `releases/vX.Y.Z` branch when it already points at the selected target, which keeps the workflow compatible with a future frozen-release-branch flow

Follow-up to the review note on #97 about avoiding races between PR merges and version creation.

## Test Plan
- `SKIP=no-commit-to-branch uvx pre-commit run --files .github/workflows/release-crates.yml`
- `git diff --check -- .github/workflows/release-crates.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-crates.yml`
