### PR TITLE
fix: Handle generate=false WebSocket requests locally

### DIFF
--- a/crates/agentic-server/src/handler/websocket/responses.rs
+++ b/crates/agentic-server/src/handler/websocket/responses.rs
@@ -12,8 +12,10 @@ use serde_json::Value;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
-use agentic_core::executor::{BoxStream, ExecuteRequest, ExecutorError};
+use agentic_core::executor::{BoxStream, ExecuteRequest, ExecutorError, RequestContext, rehydrate_conversation};
 use agentic_core::types::request_response::RequestPayload;
+use agentic_core::utils::common::utcnow_str;
+use agentic_core::{ResponseUsage, ResponsesInput};
 
 use super::super::common::{MAX_BODY_SIZE, extract_bearer};
 use super::error::WsError;
@@ -129,6 +131,11 @@ async fn handle_ws_text(
         "accepted websocket response.create"
     );
 
+    if is_initial_empty_input(&payload) {
+        debug!("handling empty websocket establishment locally");
+        return complete_websocket_establishment(sender, state, payload).await;
+    }
+
     let auth = extract_bearer(headers, state.openai_api_key.as_deref());
     let result = ExecuteRequest::new(payload, Arc::clone(&state.exec_ctx))
         .with_auth(auth)
@@ -141,6 +148,63 @@ async fn handle_ws_text(
     };
 
     stream_ws_response(sender, receiver, stream, shutdown_token, queue).await
+}
+
+fn is_initial_empty_input(payload: &RequestPayload) -> bool {
+    payload.previous_response_id.is_none()
+        && payload.conversation_id.is_none()
+        && matches!(&payload.input, ResponsesInput::Items(items) if items.is_empty())
+}
+
+async fn complete_websocket_establishment(
+    sender: &mut WsSender,
+    state: &AppState,
+    payload: RequestPayload,
+) -> Result<(), WsError> {
+    let ctx = rehydrate_conversation(payload, &state.exec_ctx).await?;
+    let created_at = utcnow_str();
+    let created_event = empty_response_event(&ctx, created_at, "response.created", "in_progress", 0, None);
+    let completed_event = empty_response_event(
+        &ctx,
+        created_at,
+        "response.completed",
+        "completed",
+        1,
+        Some(ResponseUsage::default()),
+    );
+
+    state.exec_ctx.resp_handler.execute_turn(ctx, Vec::new()).await?;
+
+    send_ws_json(sender, created_event).await?;
+    send_ws_json(sender, completed_event).await
+}
+
+fn empty_response_event(
+    ctx: &RequestContext,
+    created_at: i64,
+    event_type: &str,
+    status: &str,
+    sequence_number: u32,
+    usage: Option<ResponseUsage>,
+) -> Value {
+    serde_json::json!({
+        "type": event_type,
+        "sequence_number": sequence_number,
+        "response": {
+            "id": &ctx.response_id,
+            "object": "response",
+            "created_at": created_at,
+            "model": &ctx.enriched_request.model,
+            "status": status,
+            "output": [],
+            "usage": usage,
+            "incomplete_details": null,
+            "error": null,
+            "previous_response_id": &ctx.original_request.previous_response_id,
+            "conversation_id": &ctx.conversation_id,
+            "instructions": &ctx.enriched_request.instructions,
+        },
+    })
 }
 
 /// Stream a response from the executor to the client.

--- a/crates/agentic-server/src/handler/websocket/responses.rs
+++ b/crates/agentic-server/src/handler/websocket/responses.rs
@@ -12,10 +12,10 @@ use serde_json::Value;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
+use agentic_core::ResponseUsage;
 use agentic_core::executor::{BoxStream, ExecuteRequest, ExecutorError, RequestContext, rehydrate_conversation};
 use agentic_core::types::request_response::RequestPayload;
 use agentic_core::utils::common::utcnow_str;
-use agentic_core::{ResponseUsage, ResponsesInput};
 
 use super::super::common::{MAX_BODY_SIZE, extract_bearer};
 use super::error::WsError;
@@ -115,6 +115,7 @@ async fn handle_ws_text(
         return Err(WsError::UnexpectedType);
     }
 
+    let generate = value.get("generate").and_then(Value::as_bool);
     let mut payload = serde_json::from_value::<RequestPayload>(value).map_err(ExecutorError::from)?;
     let requested_stream = payload.stream;
     let requested_store = payload.store;
@@ -127,13 +128,14 @@ async fn handle_ws_text(
         forced_store = payload.store,
         has_previous_response_id = payload.previous_response_id.is_some(),
         has_conversation_id = payload.conversation_id.is_some(),
+        ?generate,
         tools = payload.tools.as_ref().map_or(0, Vec::len),
         "accepted websocket response.create"
     );
 
-    if is_initial_empty_input(&payload) {
-        debug!("handling empty websocket establishment locally");
-        return complete_websocket_establishment(sender, state, payload).await;
+    if generate == Some(false) {
+        debug!("handling non-generating websocket request locally");
+        return complete_without_inference(sender, state, payload).await;
     }
 
     let auth = extract_bearer(headers, state.openai_api_key.as_deref());
@@ -150,13 +152,7 @@ async fn handle_ws_text(
     stream_ws_response(sender, receiver, stream, shutdown_token, queue).await
 }
 
-fn is_initial_empty_input(payload: &RequestPayload) -> bool {
-    payload.previous_response_id.is_none()
-        && payload.conversation_id.is_none()
-        && matches!(&payload.input, ResponsesInput::Items(items) if items.is_empty())
-}
-
-async fn complete_websocket_establishment(
+async fn complete_without_inference(
     sender: &mut WsSender,
     state: &AppState,
     payload: RequestPayload,

--- a/crates/agentic-server/tests/responses_websocket_test.rs
+++ b/crates/agentic-server/tests/responses_websocket_test.rs
@@ -480,6 +480,57 @@ async fn test_websocket_first_turn_forwards_incremental_events_and_final_payload
 }
 
 #[tokio::test]
+async fn test_websocket_empty_establishment_is_local_and_reusable() {
+    let mock = MockResponsesServer::start(vec![sse_response("resp_upstream_1", "msg_upstream_1", "HELLO")]).await;
+    let fixture = storage_backed_state(&mock.url).await;
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+    let mut ws = connect_responses_ws(&gateway_url).await;
+
+    send_json(
+        &mut ws,
+        json!({
+            "type": "response.create",
+            "model": "test-model",
+            "input": [],
+            "store": false,
+            "stream": true
+        }),
+    )
+    .await;
+
+    let warmup = recv_until_completed(&mut ws).await;
+    assert_eq!(warmup.len(), 2);
+    assert_eq!(warmup[0]["type"], "response.created");
+    assert_eq!(warmup[1]["type"], "response.completed");
+    assert_eq!(warmup[0]["response"]["id"], warmup[1]["response"]["id"]);
+    assert_eq!(warmup[1]["response"]["output"], json!([]));
+    assert_eq!(warmup[1]["response"]["usage"]["total_tokens"], 0);
+    assert!(mock.request_bodies().await.is_empty());
+
+    let warmup_id = warmup[1]["response"]["id"].as_str().unwrap();
+    send_json(
+        &mut ws,
+        json!({
+            "type": "response.create",
+            "model": "test-model",
+            "previous_response_id": warmup_id,
+            "input": [{"type": "message", "role": "user", "content": "hello"}],
+            "store": false,
+            "stream": true
+        }),
+    )
+    .await;
+
+    let response = recv_until_completed(&mut ws).await;
+    assert_eq!(response.last().unwrap()["response"]["previous_response_id"], warmup_id);
+    let requests = mock.request_bodies().await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0]["input"].as_array().unwrap().len(), 1);
+    assert_eq!(requests[0]["input"][0]["role"], "user");
+    assert_eq!(requests[0]["input"][0]["content"], "hello");
+}
+
+#[tokio::test]
 async fn test_websocket_restores_namespace_tool_call_events() {
     let mock = MockResponsesServer::start(vec![sse_function_call_response(
         "resp_upstream_1",

--- a/crates/agentic-server/tests/responses_websocket_test.rs
+++ b/crates/agentic-server/tests/responses_websocket_test.rs
@@ -480,7 +480,7 @@ async fn test_websocket_first_turn_forwards_incremental_events_and_final_payload
 }
 
 #[tokio::test]
-async fn test_websocket_empty_establishment_is_local_and_reusable() {
+async fn test_websocket_generate_false_is_local_and_reusable() {
     let mock = MockResponsesServer::start(vec![sse_response("resp_upstream_1", "msg_upstream_1", "HELLO")]).await;
     let fixture = storage_backed_state(&mock.url).await;
     let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
@@ -492,6 +492,7 @@ async fn test_websocket_empty_establishment_is_local_and_reusable() {
             "type": "response.create",
             "model": "test-model",
             "input": [],
+            "generate": false,
             "store": false,
             "stream": true
         }),
@@ -528,6 +529,35 @@ async fn test_websocket_empty_establishment_is_local_and_reusable() {
     assert_eq!(requests[0]["input"].as_array().unwrap().len(), 1);
     assert_eq!(requests[0]["input"][0]["role"], "user");
     assert_eq!(requests[0]["input"][0]["content"], "hello");
+}
+
+#[tokio::test]
+async fn test_websocket_empty_input_without_generate_reaches_upstream() {
+    let mock = MockResponsesServer::start(vec![sse_response("resp_upstream_1", "msg_upstream_1", "HELLO")]).await;
+    let fixture = storage_backed_state(&mock.url).await;
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+    let mut ws = connect_responses_ws(&gateway_url).await;
+
+    send_json(
+        &mut ws,
+        json!({
+            "type": "response.create",
+            "model": "test-model",
+            "input": [],
+            "store": false,
+            "stream": true
+        }),
+    )
+    .await;
+
+    let response = recv_until_completed(&mut ws).await;
+    assert_eq!(
+        response.last().unwrap()["response"]["output"][0]["content"][0]["text"],
+        "HELLO"
+    );
+    let requests = mock.request_bodies().await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0]["input"], json!([]));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Handle Codex's non-generating WebSocket establishment request locally instead of forwarding it to vLLM.

When Codex sends `generate: false`, the gateway now persists a response checkpoint and returns `response.created` and `response.completed` without running inference. This prevents Qwen 3.5/6 from failing with `No user query found in messages` while preserving `previous_response_id` support for the first real user request.

`generate` is a WebSocket-only request control used on the `response.create` event. It is not a standard HTTP `POST /v1/responses` request parameter or a field in the returned Response object. The gateway therefore reads it from the raw WebSocket message, handles `generate: false` locally, and does not add it to or forward it through the generic HTTP/vLLM request payload.

OpenAI models and Qwen 3 tolerate an empty initial message, but Qwen 3.5/6 does not and requires a user query. Forwarding Codex's empty WebSocket establishment request directly to these stricter models therefore causes the chat template to fail.

## Test Plan

- Added tests for the WebSocket `generate: false` behavior.
- Added an integration test confirming:
  - A `generate: false` request does not reach vLLM.
  - The generated response ID is reusable.
  - The following user request reaches vLLM unchanged.
  - An empty input without `generate: false` still follows the normal inference path.
- Ran `cargo clippy --workspace --all-targets -- -D warnings`.
- Ran the full workspace test suite with eight test threads using `cargo test --workspace -- --test-threads=8`.
- Started Qwen 3.5 locally with vLLM:

  ```bash
  vllm serve Qwen/Qwen3.5-35B-A3B-FP8 \
    --reasoning-parser qwen3 \
    --enable-auto-tool-choice \
    --tool-call-parser qwen3_coder \
    --port 5050
  ```

- Started the gateway against the local vLLM server:

  ```bash
  RUST_LOG=agentic_server=debug,agentic_core=debug \
    cargo run -p agentic-server -- --llm-api-base http://127.0.0.1:5050
  ```

- Ran Qwen 3.5 through the Codex CLI interactively over WebSocket and confirmed that the non-generating establishment request is handled locally and subsequent prompts work correctly.
- This behavior is difficult to reproduce with the existing cassettes because cassette tests pass request inputs directly and do not reproduce Codex CLI's initial empty WebSocket establishment request. The issue is most reliably reproduced by running the Codex CLI locally and interacting with it over WebSocket.
