### PR TITLE
fix: normalize multi-round gateway streaming

### DIFF
--- a/crates/agentic-server-core/src/executor/engine.rs
+++ b/crates/agentic-server-core/src/executor/engine.rs
@@ -13,8 +13,8 @@ use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 use super::gateway::{
-    LoopDecision, append_gateway_calls_to_new_input, append_output_items_to_input, append_tool_outputs, classify_round,
-    execute_and_emit_output_calls, has_client_owned_calls, public_output_items,
+    GatewayStreamAccumulator, LoopDecision, append_gateway_calls_to_new_input, append_output_items_to_input,
+    append_tool_outputs, classify_round, execute_and_emit_output_calls, has_client_owned_calls, public_output_items,
 };
 use crate::executor::error::ExecutorResult;
 use crate::executor::inference::DONE_MARKER;
@@ -106,6 +106,7 @@ async fn run_until_gateway_tools_complete(
     auth: Option<&str>,
     stream_upstream: bool,
     stream_events: Option<&mpsc::UnboundedSender<String>>,
+    mut stream_accumulator: Option<&mut GatewayStreamAccumulator>,
 ) -> ExecutorResult<(ResponsePayload, RequestContext)> {
     let registry: ToolRegistry = match ctx.enriched_request.tools.as_ref() {
         Some(tools) => ToolRegistry::build_with_handlers(tools, &exec_ctx.gateway_executors).await?,
@@ -115,8 +116,18 @@ async fn run_until_gateway_tools_complete(
     let mut combined_usage: Option<ResponseUsage> = None;
 
     for round in 0..MAX_GATEWAY_TOOL_ROUNDS {
+        let output_offset = combined_output.len();
         let mut payload: ResponsePayload = if stream_upstream {
-            fetch_stream_payload(&ctx, exec_ctx, auth, &registry, stream_events).await?
+            fetch_stream_payload(
+                &ctx,
+                exec_ctx,
+                auth,
+                &registry,
+                stream_events,
+                stream_accumulator.as_deref_mut(),
+                output_offset,
+            )
+            .await?
         } else {
             fetch_blocking_payload(&ctx, exec_ctx, auth).await?
         };
@@ -124,8 +135,14 @@ async fn run_until_gateway_tools_complete(
         accumulate_usage(&mut combined_usage, payload.usage.take());
         let current_output = std::mem::take(&mut payload.output);
         let has_client_owned = has_client_owned_calls(&current_output, &registry);
-        let gateway_results =
-            execute_and_emit_output_calls(&current_output, &registry, combined_output.len(), stream_events).await?;
+        let gateway_results = execute_and_emit_output_calls(
+            &current_output,
+            &registry,
+            output_offset,
+            stream_events,
+            stream_accumulator.as_deref_mut(),
+        )
+        .await?;
         let public_output = public_output_items(&current_output, &registry, &gateway_results);
         combined_output.extend(public_output);
 
@@ -198,7 +215,7 @@ async fn run_blocking(
     exec_ctx: &ExecutionContext,
     auth: Option<&str>,
 ) -> ExecutorResult<ResponsePayload> {
-    let (payload, ctx) = run_until_gateway_tools_complete(ctx, exec_ctx, auth, false, None).await?;
+    let (payload, ctx) = run_until_gateway_tools_complete(ctx, exec_ctx, auth, false, None, None).await?;
 
     let ch = exec_ctx.conv_handler.clone();
     let rh = exec_ctx.resp_handler.clone();
@@ -214,14 +231,17 @@ fn run_stream(ctx: RequestContext, exec_ctx: Arc<ExecutionContext>, auth: Option
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
         let exec_ctx_for_run = Arc::clone(&exec_ctx);
         let mut run_handle = AbortOnDrop::new(tokio::spawn(async move {
+            let mut stream_accumulator = GatewayStreamAccumulator::new();
             run_until_gateway_tools_complete(
                 ctx,
                 exec_ctx_for_run.as_ref(),
                 auth.as_deref(),
                 true,
                 Some(&event_tx),
+                Some(&mut stream_accumulator),
             )
             .await
+            .map(|(payload, ctx)| (payload, ctx, stream_accumulator))
         }));
 
         loop {
@@ -242,8 +262,11 @@ fn run_stream(ctx: RequestContext, exec_ctx: Arc<ExecutionContext>, auth: Option
                             yield error_sse_chunk(&e.to_string());
                             yield DONE_MARKER.to_string();
                         }
-                        Ok(Ok((payload, ctx))) => {
-                            yield payload.as_terminal_response_chunk();
+                        Ok(Ok((payload, ctx, mut stream_accumulator))) => {
+                            match stream_accumulator.terminal_response_chunk(&payload) {
+                                Ok(chunk) => yield chunk,
+                                Err(e) => yield error_sse_chunk(&e.to_string()),
+                            }
                             yield DONE_MARKER.to_string();
 
                             let ch = exec_ctx.conv_handler.clone();

--- a/crates/agentic-server-core/src/executor/gateway.rs
+++ b/crates/agentic-server-core/src/executor/gateway.rs
@@ -2,13 +2,16 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use futures::stream as futures_stream;
+use serde_json::Value;
 use tokio::sync::mpsc;
 
+use crate::events::SSEEventType;
 use crate::executor::error::{ExecutorError, ExecutorResult};
 use crate::executor::request::RequestContext;
 use crate::tool::{GatewayDispatchResult, ToolError, ToolOutput, ToolRegistry, ToolType};
 use crate::types::io::output::{FunctionToolCall, GatewayCallStatus};
 use crate::types::io::{InputItem, OutputItem, ResponsesInput};
+use crate::types::request_response::ResponsePayload;
 use crate::utils::common::serialize_to_string;
 
 /// Max gateway tool calls executing at once within a round. A sliding window:
@@ -88,6 +91,84 @@ struct GatewayCallEventPlan {
     call_id: String,
     output_index: u32,
     started_output: Option<OutputItem>,
+}
+
+pub(super) struct GatewayStreamAccumulator {
+    next_sequence_number: u64,
+    emitted_created: bool,
+    emitted_in_progress: bool,
+}
+
+impl GatewayStreamAccumulator {
+    pub(super) fn new() -> Self {
+        Self {
+            next_sequence_number: 0,
+            emitted_created: false,
+            emitted_in_progress: false,
+        }
+    }
+
+    pub(super) fn should_emit_lifecycle(&mut self, event_type: SSEEventType) -> bool {
+        match event_type {
+            SSEEventType::ResponseCreated => {
+                if self.emitted_created {
+                    false
+                } else {
+                    self.emitted_created = true;
+                    true
+                }
+            }
+            SSEEventType::ResponseInProgress => {
+                if self.emitted_in_progress {
+                    false
+                } else {
+                    self.emitted_in_progress = true;
+                    true
+                }
+            }
+            _ => true,
+        }
+    }
+
+    pub(super) fn emit_event(
+        &mut self,
+        sender: &mpsc::UnboundedSender<String>,
+        event: &mut Value,
+        output_offset: usize,
+    ) -> ExecutorResult<()> {
+        self.normalize_event(event, output_offset);
+        emit_sse_json(sender, event)
+    }
+
+    pub(super) fn terminal_response_chunk(&mut self, payload: &ResponsePayload) -> ExecutorResult<String> {
+        let mut event = serde_json::json!({
+            "type": payload.terminal_event_type(),
+            "response": payload,
+        });
+        self.normalize_event(&mut event, 0);
+        let event_json = serialize_to_string(&event).map_err(ExecutorError::JsonError)?;
+        Ok(format!("data: {event_json}\n\n"))
+    }
+
+    fn normalize_event(&mut self, event: &mut Value, output_offset: usize) {
+        event["sequence_number"] = Value::from(self.take_sequence_number());
+        rebase_output_index(event, output_offset);
+    }
+
+    fn take_sequence_number(&mut self) -> u64 {
+        let sequence_number = self.next_sequence_number;
+        self.next_sequence_number = self.next_sequence_number.saturating_add(1);
+        sequence_number
+    }
+}
+
+fn rebase_output_index(value: &mut Value, output_offset: usize) {
+    let Some(offset) = u64::try_from(output_offset).ok().filter(|offset| *offset > 0) else {
+        return;
+    };
+    if let Some(index) = value.get("output_index").and_then(Value::as_u64) {
+        value["output_index"] = Value::from(index.saturating_add(offset));
+    }
 }
 
 fn function_calls(output_items: &[OutputItem]) -> Vec<FunctionToolCall> {
@@ -279,8 +360,12 @@ fn output_item_value(item: &OutputItem) -> ExecutorResult<serde_json::Value> {
 fn emit_gateway_start_events(
     plans: &[GatewayCallEventPlan],
     stream_events: Option<&mpsc::UnboundedSender<String>>,
+    stream_accumulator: Option<&mut GatewayStreamAccumulator>,
 ) -> ExecutorResult<()> {
     let Some(sender) = stream_events else {
+        return Ok(());
+    };
+    let Some(stream_accumulator) = stream_accumulator else {
         return Ok(());
     };
     for plan in plans {
@@ -288,34 +373,34 @@ fn emit_gateway_start_events(
             continue;
         };
         let item = output_item_value(output_item)?;
-        let added_event = serde_json::json!({
+        let mut added_event = serde_json::json!({
                 "type": "response.output_item.added",
                 "output_index": plan.output_index,
                 "item": item
         });
-        emit_sse_json(sender, &added_event)?;
+        stream_accumulator.emit_event(sender, &mut added_event, 0)?;
         match output_item {
             OutputItem::WebSearchCall(web_search_call) => {
-                let in_progress_event = serde_json::json!({
+                let mut in_progress_event = serde_json::json!({
                         "type": "response.web_search_call.in_progress",
                         "item_id": web_search_call.id,
                         "output_index": plan.output_index
                 });
-                emit_sse_json(sender, &in_progress_event)?;
-                let searching_event = serde_json::json!({
+                stream_accumulator.emit_event(sender, &mut in_progress_event, 0)?;
+                let mut searching_event = serde_json::json!({
                         "type": "response.web_search_call.searching",
                         "item_id": web_search_call.id,
                         "output_index": plan.output_index
                 });
-                emit_sse_json(sender, &searching_event)?;
+                stream_accumulator.emit_event(sender, &mut searching_event, 0)?;
             }
             OutputItem::McpToolCall(mcp_tool_call) => {
-                let in_progress_event = serde_json::json!({
+                let mut in_progress_event = serde_json::json!({
                         "type": "response.mcp_tool_call.in_progress",
                         "item_id": mcp_tool_call.id,
                         "output_index": plan.output_index
                 });
-                emit_sse_json(sender, &in_progress_event)?;
+                stream_accumulator.emit_event(sender, &mut in_progress_event, 0)?;
             }
             OutputItem::Message(_) | OutputItem::FunctionCall(_) | OutputItem::Reasoning(_) | OutputItem::Unknown => {}
         }
@@ -327,8 +412,12 @@ fn emit_gateway_completed_events(
     results: &[GatewayCallResult],
     plans: &[GatewayCallEventPlan],
     stream_events: Option<&mpsc::UnboundedSender<String>>,
+    stream_accumulator: Option<&mut GatewayStreamAccumulator>,
 ) -> ExecutorResult<()> {
     let Some(sender) = stream_events else {
+        return Ok(());
+    };
+    let Some(stream_accumulator) = stream_accumulator else {
         return Ok(());
     };
     for result in results {
@@ -349,19 +438,19 @@ fn emit_gateway_completed_events(
             }
         };
         let item = output_item_value(public_output)?;
-        let completed_event = serde_json::json!({
+        let mut completed_event = serde_json::json!({
                 "type": event_type,
                 "item_id": item_id,
                 "output_index": output_index,
                 "item": item.clone()
         });
-        emit_sse_json(sender, &completed_event)?;
-        let done_event = serde_json::json!({
+        stream_accumulator.emit_event(sender, &mut completed_event, 0)?;
+        let mut done_event = serde_json::json!({
                 "type": "response.output_item.done",
                 "output_index": output_index,
                 "item": item
         });
-        emit_sse_json(sender, &done_event)?;
+        stream_accumulator.emit_event(sender, &mut done_event, 0)?;
     }
     Ok(())
 }
@@ -371,12 +460,20 @@ pub(super) async fn execute_and_emit_output_calls(
     registry: &ToolRegistry,
     output_offset: usize,
     stream_events: Option<&mpsc::UnboundedSender<String>>,
+    stream_accumulator: Option<&mut GatewayStreamAccumulator>,
 ) -> ExecutorResult<Vec<GatewayCallResult>> {
     let event_plans = gateway_event_plans(output_items, registry, output_offset);
-    emit_gateway_start_events(&event_plans, stream_events)?;
-    let gateway_results = execute_output_calls(output_items, registry).await?;
-    emit_gateway_completed_events(&gateway_results, &event_plans, stream_events)?;
-    Ok(gateway_results)
+    if let Some(accumulator) = stream_accumulator {
+        emit_gateway_start_events(&event_plans, stream_events, Some(accumulator))?;
+        let gateway_results = execute_output_calls(output_items, registry).await?;
+        emit_gateway_completed_events(&gateway_results, &event_plans, stream_events, Some(accumulator))?;
+        Ok(gateway_results)
+    } else {
+        emit_gateway_start_events(&event_plans, stream_events, None)?;
+        let gateway_results = execute_output_calls(output_items, registry).await?;
+        emit_gateway_completed_events(&gateway_results, &event_plans, stream_events, None)?;
+        Ok(gateway_results)
+    }
 }
 
 pub(super) fn append_input_item(input: &mut ResponsesInput, item: InputItem) {

--- a/crates/agentic-server-core/src/executor/upstream.rs
+++ b/crates/agentic-server-core/src/executor/upstream.rs
@@ -8,11 +8,20 @@ use tokio::sync::mpsc;
 use crate::events::{EventPayload, SSEEventType, SSEItemType, normalize_sse_line};
 use crate::executor::accumulator::ResponseAccumulator;
 use crate::executor::error::{ExecutorError, ExecutorResult};
+use crate::executor::gateway::GatewayStreamAccumulator;
 use crate::executor::inference::{call_inference, fetch_response_json};
 use crate::executor::request::{ExecutionContext, RequestContext};
 use crate::tool::ToolRegistry;
 use crate::types::request_response::ResponsePayload;
 use crate::utils::common::serialize_to_string;
+
+struct StreamEmitContext<'a> {
+    request: &'a RequestContext,
+    registry: &'a ToolRegistry,
+    sender: &'a mpsc::UnboundedSender<String>,
+    accumulator: &'a mut GatewayStreamAccumulator,
+    output_offset: usize,
+}
 
 pub(super) async fn fetch_blocking_payload(
     ctx: &RequestContext,
@@ -43,6 +52,8 @@ pub(super) async fn fetch_stream_payload(
     auth: Option<&str>,
     registry: &ToolRegistry,
     stream_events: Option<&mpsc::UnboundedSender<String>>,
+    stream_accumulator: Option<&mut GatewayStreamAccumulator>,
+    output_offset: usize,
 ) -> ExecutorResult<ResponsePayload> {
     let url = exec_ctx.responses_url();
     let upstream_request = ctx.enriched_request.to_upstream_request(true)?;
@@ -57,14 +68,20 @@ pub(super) async fn fetch_stream_payload(
     let mut acc = ResponseAccumulator::new(ctx.response_id.clone(), ctx.conversation_id.clone());
     let mut hidden_gateway_item_ids = HashSet::new();
     let mut pending_unnamed_function_events = HashMap::<String, Vec<String>>::new();
+    let mut stream_accumulator = stream_accumulator;
     while let Some(line_result) = line_stream.next().await {
         let line = line_result?;
-        if let Some(sender) = stream_events {
-            emit_upstream_stream_event(
-                &line,
-                ctx,
+        if let (Some(sender), Some(accumulator)) = (stream_events, stream_accumulator.as_deref_mut()) {
+            let mut emit_ctx = StreamEmitContext {
+                request: ctx,
                 registry,
                 sender,
+                accumulator,
+                output_offset,
+            };
+            emit_upstream_stream_event(
+                &line,
+                &mut emit_ctx,
                 &mut hidden_gateway_item_ids,
                 &mut pending_unnamed_function_events,
             )?;
@@ -83,9 +100,7 @@ pub(super) async fn fetch_stream_payload(
 
 fn emit_upstream_stream_event(
     line: &str,
-    ctx: &RequestContext,
-    registry: &ToolRegistry,
-    sender: &mpsc::UnboundedSender<String>,
+    emit_ctx: &mut StreamEmitContext<'_>,
     hidden_gateway_item_ids: &mut HashSet<String>,
     pending_unnamed_function_events: &mut HashMap<String, Vec<String>>,
 ) -> ExecutorResult<()> {
@@ -100,8 +115,13 @@ fn emit_upstream_stream_event(
     let Some(frame) = normalize_sse_line(line) else {
         return Ok(());
     };
-    if should_hide_upstream_event(frame.event_type, &frame.payload, registry, hidden_gateway_item_ids)
-        || is_terminal_response_event(frame.event_type)
+    if should_hide_upstream_event(
+        frame.event_type,
+        &frame.payload,
+        emit_ctx.registry,
+        hidden_gateway_item_ids,
+    ) || is_terminal_response_event(frame.event_type)
+        || !emit_ctx.accumulator.should_emit_lifecycle(frame.event_type)
     {
         drop_pending_function_events(&frame.payload, pending_unnamed_function_events);
         return Ok(());
@@ -109,39 +129,29 @@ fn emit_upstream_stream_event(
     if defer_or_flush_function_event(
         line,
         &frame.payload,
-        ctx,
-        registry,
-        sender,
+        emit_ctx,
         hidden_gateway_item_ids,
         pending_unnamed_function_events,
     )? {
         return Ok(());
     }
 
-    emit_stream_line(data, ctx, registry, sender)
+    emit_stream_line(data, emit_ctx)
 }
 
-fn emit_stream_line(
-    data: &str,
-    ctx: &RequestContext,
-    registry: &ToolRegistry,
-    sender: &mpsc::UnboundedSender<String>,
-) -> ExecutorResult<()> {
+fn emit_stream_line(data: &str, emit_ctx: &mut StreamEmitContext<'_>) -> ExecutorResult<()> {
     let mut value = serde_json::from_str::<Value>(data).map_err(ExecutorError::JsonError)?;
-    apply_context_response_ids(&mut value, ctx);
-    registry.restore_stream_event_value(&mut value);
-    let event_json = serialize_to_string(&value).map_err(ExecutorError::JsonError)?;
-    sender
-        .send(format!("data: {event_json}\n\n"))
-        .map_err(|_| ExecutorError::StreamError("stream receiver closed while emitting upstream event".to_owned()))
+    apply_context_response_ids(&mut value, emit_ctx.request);
+    emit_ctx.registry.restore_stream_event_value(&mut value);
+    emit_ctx
+        .accumulator
+        .emit_event(emit_ctx.sender, &mut value, emit_ctx.output_offset)
 }
 
 fn defer_or_flush_function_event(
     line: &str,
     payload: &EventPayload,
-    ctx: &RequestContext,
-    registry: &ToolRegistry,
-    sender: &mpsc::UnboundedSender<String>,
+    emit_ctx: &mut StreamEmitContext<'_>,
     hidden_gateway_item_ids: &mut HashSet<String>,
     pending_unnamed_function_events: &mut HashMap<String, Vec<String>>,
 ) -> ExecutorResult<bool> {
@@ -168,12 +178,12 @@ fn defer_or_flush_function_event(
             Ok(true)
         }
         EventPayload::FunctionCallArgsDone { item_id, name, .. } => {
-            if registry.is_gateway_owned_name(name) {
+            if emit_ctx.registry.is_gateway_owned_name(name) {
                 hidden_gateway_item_ids.insert(item_id.clone());
                 pending_unnamed_function_events.remove(item_id);
                 return Ok(true);
             }
-            flush_pending_function_events(item_id, ctx, registry, sender, pending_unnamed_function_events)?;
+            flush_pending_function_events(item_id, emit_ctx, pending_unnamed_function_events)?;
             Ok(false)
         }
         EventPayload::OutputItemDone {
@@ -185,13 +195,13 @@ fn defer_or_flush_function_event(
             if item
                 .get("name")
                 .and_then(Value::as_str)
-                .is_some_and(|name| registry.is_gateway_owned_name(name))
+                .is_some_and(|name| emit_ctx.registry.is_gateway_owned_name(name))
             {
                 hidden_gateway_item_ids.insert(item_id.clone());
                 pending_unnamed_function_events.remove(item_id);
                 return Ok(true);
             }
-            flush_pending_function_events(item_id, ctx, registry, sender, pending_unnamed_function_events)?;
+            flush_pending_function_events(item_id, emit_ctx, pending_unnamed_function_events)?;
             Ok(false)
         }
         _ => Ok(false),
@@ -200,9 +210,7 @@ fn defer_or_flush_function_event(
 
 fn flush_pending_function_events(
     item_id: &str,
-    ctx: &RequestContext,
-    registry: &ToolRegistry,
-    sender: &mpsc::UnboundedSender<String>,
+    emit_ctx: &mut StreamEmitContext<'_>,
     pending_unnamed_function_events: &mut HashMap<String, Vec<String>>,
 ) -> ExecutorResult<()> {
     let Some(lines) = pending_unnamed_function_events.remove(item_id) else {
@@ -212,7 +220,7 @@ fn flush_pending_function_events(
         let Some(data) = line.strip_prefix("data: ") else {
             continue;
         };
-        emit_stream_line(data.trim(), ctx, registry, sender)?;
+        emit_stream_line(data.trim(), emit_ctx)?;
     }
     Ok(())
 }

--- a/crates/agentic-server-core/src/types/request_response.rs
+++ b/crates/agentic-server-core/src/types/request_response.rs
@@ -152,7 +152,7 @@ impl ResponsePayload {
         format!("data: {json_str}\n\n")
     }
 
-    fn terminal_event_type(&self) -> &'static str {
+    pub(crate) fn terminal_event_type(&self) -> &'static str {
         match self.status.as_str() {
             "incomplete" => "response.incomplete",
             "failed" | "error" => "response.failed",

--- a/crates/agentic-server-core/tests/web_search_tool_test.rs
+++ b/crates/agentic-server-core/tests/web_search_tool_test.rs
@@ -436,6 +436,52 @@ fn text_sse_response(text: &str) -> support::MockResponse {
     ])
 }
 
+fn text_sse_response_with_output_index(text: &str, output_index: u32) -> support::MockResponse {
+    sse_response([
+        serde_json::json!({
+            "type": "response.created",
+            "response": {"id": "resp_final", "status": "in_progress", "usage": null}
+        }),
+        serde_json::json!({
+            "type": "response.in_progress",
+            "response": {"id": "resp_final", "status": "in_progress", "usage": null}
+        }),
+        serde_json::json!({
+            "type": "response.output_item.added",
+            "output_index": output_index,
+            "item": {
+                "id": "msg_final",
+                "type": "message",
+                "role": "assistant",
+                "status": "in_progress",
+                "content": []
+            }
+        }),
+        serde_json::json!({
+            "type": "response.output_text.delta",
+            "item_id": "msg_final",
+            "output_index": output_index,
+            "content_index": 0,
+            "delta": text
+        }),
+        serde_json::json!({
+            "type": "response.output_item.done",
+            "output_index": output_index,
+            "item": {
+                "id": "msg_final",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": text, "annotations": []}]
+            }
+        }),
+        serde_json::json!({
+            "type": "response.completed",
+            "response": {"id": "resp_final", "status": "completed", "usage": null}
+        }),
+    ])
+}
+
 fn mixed_web_search_and_client_function_response() -> support::MockResponse {
     support::MockResponse::Json(
         serde_json::json!({
@@ -924,6 +970,106 @@ async fn stream_emits_web_search_lifecycle_events_before_final_payload() {
     let output = completed_event["response"]["output"].as_array().unwrap();
     assert!(output.iter().any(|item| item["type"] == "web_search_call"));
     assert!(output.iter().any(|item| item["type"] == "message"));
+}
+
+#[tokio::test]
+async fn multi_round_stream_has_single_lifecycle_and_monotonic_public_sequence() {
+    let (you_url, mut captured_you, _you_handle) = spawn_mock_you().await;
+    let llm = support::MockServer::start_deque(vec![
+        web_search_function_call_sse_response(),
+        text_sse_response_with_output_index("Use async carefully.", 0),
+    ])
+    .await;
+    let exec_ctx = build_exec_ctx(llm.url(), you_url).await;
+    let web_search: ResponsesTool = serde_json::from_value(serde_json::json!({"type": "web_search_preview"})).unwrap();
+    let payload = RequestPayload {
+        model: "test-model".to_owned(),
+        input: ResponsesInput::Text("look up rust async".to_owned()),
+        instructions: None,
+        previous_response_id: None,
+        conversation_id: None,
+        tools: Some(vec![web_search]),
+        tool_choice: None,
+        stream: true,
+        store: true,
+        include: None,
+        temperature: None,
+        top_p: None,
+        max_output_tokens: Some(1024),
+        truncation: None,
+        metadata: None,
+    };
+
+    let result = ExecuteRequest::new(payload, Arc::clone(&exec_ctx)).run().await.unwrap();
+    let Either::Right(stream) = result else {
+        panic!("expected streaming response");
+    };
+    let chunks: Vec<String> = stream.collect().await;
+    captured_you.recv().await.expect("mock You.com should receive request");
+
+    let json_events: Vec<serde_json::Value> = chunks
+        .iter()
+        .filter_map(|chunk| {
+            let data = chunk.trim_end_matches('\n').strip_prefix("data: ")?;
+            (data != "[DONE]").then(|| serde_json::from_str(data).ok())?
+        })
+        .collect();
+    let event_types: Vec<&str> = json_events.iter().filter_map(|event| event["type"].as_str()).collect();
+    assert_eq!(
+        event_types
+            .iter()
+            .filter(|event_type| **event_type == "response.created")
+            .count(),
+        1,
+        "multi-round stream should expose one logical response.created: {event_types:?}"
+    );
+    assert_eq!(
+        event_types
+            .iter()
+            .filter(|event_type| **event_type == "response.in_progress")
+            .count(),
+        1,
+        "multi-round stream should expose one logical response.in_progress: {event_types:?}"
+    );
+
+    let sequence_numbers: Vec<u64> = json_events
+        .iter()
+        .map(|event| {
+            event["sequence_number"]
+                .as_u64()
+                .unwrap_or_else(|| panic!("event missing sequence_number: {event}"))
+        })
+        .collect();
+    assert_eq!(
+        sequence_numbers,
+        (0..u64::try_from(sequence_numbers.len()).unwrap()).collect::<Vec<_>>(),
+        "public sequence_number must be contiguous across upstream, synthetic, and terminal frames"
+    );
+
+    let output_events: Vec<(&str, u64)> = json_events
+        .iter()
+        .filter_map(|event| Some((event["type"].as_str()?, event["output_index"].as_u64()?)))
+        .collect();
+    assert!(
+        output_events.contains(&("response.output_item.added", 0)),
+        "synthetic web_search_call should occupy output_index 0: {output_events:?}"
+    );
+    assert!(
+        output_events.contains(&("response.output_item.done", 0)),
+        "synthetic web_search_call done should occupy output_index 0: {output_events:?}"
+    );
+    assert!(
+        output_events.contains(&("response.output_item.added", 1)),
+        "round-two message should be rebased to output_index 1: {output_events:?}"
+    );
+    assert!(
+        output_events.contains(&("response.output_text.delta", 1)),
+        "round-two text delta should be rebased to output_index 1: {output_events:?}"
+    );
+    assert!(
+        output_events.contains(&("response.output_item.done", 1)),
+        "round-two message done should be rebased to output_index 1: {output_events:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #119.

**Summary**
- Add a gateway stream accumulator that owns client-visible SSE lifecycle de-duping, sequence_number assignment, and output_index rebasing across gateway rounds.
- Route upstream forwarded frames, synthetic web_search/MCP frames, and the terminal response event through the same stream accumulator.
- Add a multi-round streaming regression test covering a gateway tool round followed by a final text round.

**Test Plan**
- cargo fmt --check
- cargo test -p agentic-server-core --test web_search_tool_test multi_round_stream_has_single_lifecycle_and_monotonic_public_sequence
- cargo test -p agentic-server-core --test web_search_tool_test
- cargo test -p agentic-server-core
- cargo clippy --all-targets -- -D warnings
- cargo test