### PR TITLE
feat: add Kubernetes deployment path

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  kubernetes:
+    runs-on: ubuntu-latest
+    env:
+      KUBECTL_VERSION: v1.36.2
+      KUBECTL_SHA256: 1e9045ec32bea85da43de85f0065358529ea7c7a152eca78154fba5b58c27d82
+      KUBECONFORM_VERSION: v0.7.0
+      KUBECONFORM_SHA256: c31518ddd122663b3f3aa874cfe8178cb0988de944f29c74a0b9260920d115d3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install pinned Kubernetes validators
+        run: |
+          curl --fail --location --silent --show-error \
+            "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+            --output "${RUNNER_TEMP}/kubectl"
+          echo "${KUBECTL_SHA256}  ${RUNNER_TEMP}/kubectl" | sha256sum --check
+          chmod +x "${RUNNER_TEMP}/kubectl"
+
+          curl --fail --location --silent --show-error \
+            "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            --output "${RUNNER_TEMP}/kubeconform.tar.gz"
+          echo "${KUBECONFORM_SHA256}  ${RUNNER_TEMP}/kubeconform.tar.gz" | sha256sum --check
+          tar --extract --gzip --file "${RUNNER_TEMP}/kubeconform.tar.gz" --directory "${RUNNER_TEMP}" kubeconform
+
+      - name: Render and validate Kubernetes manifests
+        run: |
+          set -o pipefail
+          "${RUNNER_TEMP}/kubectl" kustomize deploy/kubernetes \
+            | "${RUNNER_TEMP}/kubeconform" \
+                -kubernetes-version 1.36.0 \
+                -strict \
+                -summary
+
   rust:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
+ "serde_yml",
  "sqlx",
  "thiserror",
  "tokio",

--- a/crates/agentic-server-core/src/readiness.rs
+++ b/crates/agentic-server-core/src/readiness.rs
@@ -22,6 +22,43 @@ fn timeout_error(url: &str, timeout_s: f64) -> Error {
     }
 }
 
+/// Result of a single bounded inference-service health probe.
+#[derive(Debug)]
+pub enum LlmReadiness {
+    Ready,
+    Rejected(reqwest::StatusCode),
+    Unreachable(reqwest::Error),
+    TimedOut,
+}
+
+/// Probe the inference service's `/health` endpoint once.
+///
+/// # Errors
+///
+/// Returns an error when the configured bearer credential cannot be represented
+/// as an HTTP header.
+pub async fn probe_llm_readiness(
+    client: &reqwest::Client,
+    llm_api_base: &str,
+    openai_api_key: Option<&str>,
+    timeout: Duration,
+) -> Result<LlmReadiness, Error> {
+    let base = llm_api_base.trim_end_matches('/');
+    let url = format!("{base}/health");
+    let mut request = client.get(url);
+    if let Some(key) = openai_api_key.map(str::trim).filter(|key| !key.is_empty()) {
+        let value = reqwest::header::HeaderValue::from_str(&format!("Bearer {key}"))?;
+        request = request.header(reqwest::header::AUTHORIZATION, value);
+    }
+
+    Ok(match tokio::time::timeout(timeout, request.send()).await {
+        Ok(Ok(response)) if response.status() == reqwest::StatusCode::OK => LlmReadiness::Ready,
+        Ok(Ok(response)) => LlmReadiness::Rejected(response.status()),
+        Ok(Err(error)) => LlmReadiness::Unreachable(error),
+        Err(_) => LlmReadiness::TimedOut,
+    })
+}
+
 /// Poll LLM `/health` until it responds 200 or the timeout is reached.
 ///
 /// # Errors
@@ -31,22 +68,7 @@ pub async fn wait_llm_ready(config: &Config) -> Result<(), Error> {
     let base = config.llm_api_base.trim_end_matches('/');
     let url = format!("{base}/health");
 
-    let mut headers = reqwest::header::HeaderMap::new();
-    if let Some(key) = config.openai_api_key.as_deref() {
-        let trimmed = key.trim();
-        if !trimmed.is_empty() {
-            headers.insert(
-                reqwest::header::AUTHORIZATION,
-                reqwest::header::HeaderValue::from_str(&format!("Bearer {trimmed}"))?,
-            );
-        }
-    }
-
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(2))
-        .default_headers(headers)
-        .build()
-        .map_err(Error::HttpClient)?;
+    let client = reqwest::Client::builder().build().map_err(Error::HttpClient)?;
 
     let timeout = checked_duration_seconds("llm_ready_timeout_s", config.llm_ready_timeout_s)?;
     let interval = checked_duration_seconds("llm_ready_interval_s", config.llm_ready_interval_s)?;
@@ -61,9 +83,17 @@ pub async fn wait_llm_ready(config: &Config) -> Result<(), Error> {
             return Err(timeout_error(&url, config.llm_ready_timeout_s));
         }
 
-        match tokio::time::timeout(remaining, client.get(&url).send()).await {
-            Ok(Ok(resp)) if resp.status().as_u16() == 200 => return Ok(()),
-            _ => {}
+        if matches!(
+            probe_llm_readiness(
+                &client,
+                &config.llm_api_base,
+                config.openai_api_key.as_deref(),
+                Duration::from_secs(2).min(remaining),
+            )
+            .await?,
+            LlmReadiness::Ready
+        ) {
+            return Ok(());
         }
 
         let elapsed = start.elapsed();
@@ -87,7 +117,7 @@ pub async fn wait_llm_ready(config: &Config) -> Result<(), Error> {
 mod tests {
     use std::time::Duration;
 
-    use super::{checked_duration_seconds, timeout_error};
+    use super::{checked_duration_seconds, probe_llm_readiness, timeout_error};
 
     #[test]
     fn checked_duration_rejects_non_positive() {
@@ -133,5 +163,19 @@ mod tests {
         let interval = Duration::from_secs(2);
         let remaining = Duration::from_millis(100);
         assert_eq!(interval.min(remaining), Duration::from_millis(100));
+    }
+
+    #[tokio::test]
+    async fn probe_rejects_invalid_bearer_header_before_network_io() {
+        let error = probe_llm_readiness(
+            &reqwest::Client::new(),
+            "http://127.0.0.1:1",
+            Some("invalid\nkey"),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, crate::error::Error::InvalidHeader(_)));
     }
 }

--- a/crates/agentic-server-core/src/readiness.rs
+++ b/crates/agentic-server-core/src/readiness.rs
@@ -5,6 +5,9 @@ use tracing::info;
 use crate::config::Config;
 use crate::error::Error;
 
+/// Maximum duration of one inference-service readiness probe.
+pub const LLM_READINESS_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
 fn checked_duration_seconds(name: &str, value: f64) -> Result<Duration, Error> {
     if !value.is_finite() || value <= 0.0 {
         return Err(Error::Config(format!(
@@ -24,11 +27,27 @@ fn timeout_error(url: &str, timeout_s: f64) -> Error {
 
 /// Result of a single bounded inference-service health probe.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum LlmReadiness {
     Ready,
     Rejected(reqwest::StatusCode),
     Unreachable(reqwest::Error),
     TimedOut,
+}
+
+/// Build the dedicated HTTP client used for inference-service health probes.
+///
+/// The client rejects redirects so an authentication page or generic UI cannot
+/// turn an unsuccessful `/health` response into a false-positive readiness result.
+///
+/// # Errors
+///
+/// Returns an error when the HTTP client cannot be constructed.
+pub fn llm_readiness_client() -> Result<reqwest::Client, Error> {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(Error::HttpClient)
 }
 
 /// Probe the inference service's `/health` endpoint once.
@@ -68,7 +87,7 @@ pub async fn wait_llm_ready(config: &Config) -> Result<(), Error> {
     let base = config.llm_api_base.trim_end_matches('/');
     let url = format!("{base}/health");
 
-    let client = reqwest::Client::builder().build().map_err(Error::HttpClient)?;
+    let client = llm_readiness_client()?;
 
     let timeout = checked_duration_seconds("llm_ready_timeout_s", config.llm_ready_timeout_s)?;
     let interval = checked_duration_seconds("llm_ready_interval_s", config.llm_ready_interval_s)?;
@@ -88,7 +107,7 @@ pub async fn wait_llm_ready(config: &Config) -> Result<(), Error> {
                 &client,
                 &config.llm_api_base,
                 config.openai_api_key.as_deref(),
-                Duration::from_secs(2).min(remaining),
+                LLM_READINESS_PROBE_TIMEOUT.min(remaining),
             )
             .await?,
             LlmReadiness::Ready
@@ -115,9 +134,38 @@ pub async fn wait_llm_ready(config: &Config) -> Result<(), Error> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
-    use super::{checked_duration_seconds, probe_llm_readiness, timeout_error};
+    use axum::Router;
+    use axum::http::HeaderMap;
+    use axum::response::{IntoResponse, Redirect};
+    use axum::routing::get;
+    use http::StatusCode;
+    use tokio::net::TcpListener;
+
+    use super::{checked_duration_seconds, probe_llm_readiness, timeout_error, wait_llm_ready};
+
+    fn test_config(llm_api_base: String) -> crate::config::Config {
+        crate::config::Config {
+            llm_api_base,
+            openai_api_key: Some("test-key".to_owned()),
+            llm_ready_timeout_s: 0.5,
+            llm_ready_interval_s: 0.01,
+            skip_llm_ready_check: false,
+            db_url: None,
+            postgres: crate::config::PostgresConfig::default(),
+            sqlite: crate::config::SqliteConfig::default(),
+        }
+    }
+
+    async fn spawn_upstream(app: Router) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        (format!("http://{addr}"), handle)
+    }
 
     #[test]
     fn checked_duration_rejects_non_positive() {
@@ -177,5 +225,60 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(error, crate::error::Error::InvalidHeader(_)));
+    }
+
+    #[tokio::test]
+    async fn wait_llm_ready_retries_with_authentication_until_success() {
+        let requests = Arc::new(AtomicUsize::new(0));
+        let app = Router::new().route(
+            "/health",
+            get({
+                let requests = Arc::clone(&requests);
+                move |headers: HeaderMap| {
+                    let requests = Arc::clone(&requests);
+                    async move {
+                        if headers.get("authorization").and_then(|value| value.to_str().ok()) != Some("Bearer test-key")
+                        {
+                            return StatusCode::UNAUTHORIZED;
+                        }
+                        if requests.fetch_add(1, Ordering::SeqCst) == 0 {
+                            StatusCode::SERVICE_UNAVAILABLE
+                        } else {
+                            StatusCode::NO_CONTENT
+                        }
+                    }
+                }
+            }),
+        );
+        let (url, upstream) = spawn_upstream(app).await;
+
+        wait_llm_ready(&test_config(url)).await.unwrap();
+
+        assert!(requests.load(Ordering::SeqCst) >= 2);
+        upstream.abort();
+    }
+
+    #[tokio::test]
+    async fn wait_llm_ready_rejects_redirects_until_final_timeout() {
+        let app = Router::new()
+            .route("/health", get(|| async { Redirect::temporary("/login") }))
+            .route("/login", get(|| async { StatusCode::OK.into_response() }));
+        let (url, upstream) = spawn_upstream(app).await;
+        let mut config = test_config(url.clone());
+        config.llm_ready_timeout_s = 0.05;
+
+        let error = wait_llm_ready(&config).await.unwrap_err();
+
+        match error {
+            crate::error::Error::LlmTimeout {
+                url: timed_out_url,
+                timeout_s,
+            } => {
+                assert_eq!(timed_out_url, format!("{url}/health"));
+                assert!((timeout_s - 0.05).abs() < f64::EPSILON);
+            }
+            other => panic!("expected timeout error, got {other:?}"),
+        }
+        upstream.abort();
     }
 }

--- a/crates/agentic-server-core/src/readiness.rs
+++ b/crates/agentic-server-core/src/readiness.rs
@@ -52,14 +52,14 @@ pub async fn probe_llm_readiness(
     }
 
     Ok(match tokio::time::timeout(timeout, request.send()).await {
-        Ok(Ok(response)) if response.status() == reqwest::StatusCode::OK => LlmReadiness::Ready,
+        Ok(Ok(response)) if response.status().is_success() => LlmReadiness::Ready,
         Ok(Ok(response)) => LlmReadiness::Rejected(response.status()),
         Ok(Err(error)) => LlmReadiness::Unreachable(error),
         Err(_) => LlmReadiness::TimedOut,
     })
 }
 
-/// Poll LLM `/health` until it responds 200 or the timeout is reached.
+/// Poll LLM `/health` until it responds successfully or the timeout is reached.
 ///
 /// # Errors
 ///

--- a/crates/agentic-server/Cargo.toml
+++ b/crates/agentic-server/Cargo.toml
@@ -35,6 +35,7 @@ rand = "0.8"
 rsa = "0.9"
 serde_json.workspace = true
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "any", "sqlite"] }
+serde_yml = "0.0.12"
 tokio = { workspace = true, features = ["test-util"] }
 tokio-tungstenite.workspace = true
 uuid = { version = "1", features = ["v7"] }

--- a/crates/agentic-server/benches/gateway_bench.rs
+++ b/crates/agentic-server/benches/gateway_bench.rs
@@ -173,6 +173,8 @@ async fn spawn_gateway(llm_url: &str) -> (Arc<reqwest::Client>, String) {
     let state = AppState {
         proxy_state,
         exec_ctx,
+        llm_readiness_client: agentic_core::readiness::llm_readiness_client().expect("readiness client"),
+        readiness_tracker: agentic_server::app::ReadinessTracker::default(),
         shutdown_token: CancellationToken::new(),
         websocket_tracker: WebSocketTracker::default(),
         llm_api_base: config.llm_api_base,

--- a/crates/agentic-server/benches/gateway_bench.rs
+++ b/crates/agentic-server/benches/gateway_bench.rs
@@ -176,6 +176,7 @@ async fn spawn_gateway(llm_url: &str) -> (Arc<reqwest::Client>, String) {
         shutdown_token: CancellationToken::new(),
         websocket_tracker: WebSocketTracker::default(),
         llm_api_base: config.llm_api_base,
+        skip_llm_ready_check: config.skip_llm_ready_check,
         openai_api_key: config.openai_api_key,
     };
 

--- a/crates/agentic-server/benches/proxy_bench.rs
+++ b/crates/agentic-server/benches/proxy_bench.rs
@@ -96,6 +96,7 @@ async fn spawn_gateway(config: Config) -> String {
         shutdown_token: CancellationToken::new(),
         websocket_tracker: WebSocketTracker::default(),
         llm_api_base: config.llm_api_base,
+        skip_llm_ready_check: config.skip_llm_ready_check,
         openai_api_key: config.openai_api_key,
     };
     let server_config = ServerConfig::from_env();

--- a/crates/agentic-server/benches/proxy_bench.rs
+++ b/crates/agentic-server/benches/proxy_bench.rs
@@ -93,6 +93,8 @@ async fn spawn_gateway(config: Config) -> String {
     let state = AppState {
         proxy_state,
         exec_ctx,
+        llm_readiness_client: agentic_core::readiness::llm_readiness_client().expect("readiness client"),
+        readiness_tracker: agentic_server::app::ReadinessTracker::default(),
         shutdown_token: CancellationToken::new(),
         websocket_tracker: WebSocketTracker::default(),
         llm_api_base: config.llm_api_base,

--- a/crates/agentic-server/src/app.rs
+++ b/crates/agentic-server/src/app.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 
 use axum::Router;
 use axum::middleware;
 use axum::routing::{get, post};
 use http::HeaderValue;
-use tokio::sync::Notify;
 #[cfg(debug_assertions)]
 use tokio::sync::oneshot;
+use tokio::sync::{Notify, Semaphore, SemaphorePermit};
 use tokio_util::sync::CancellationToken;
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 
@@ -30,6 +30,69 @@ struct WebSocketTrackerInner {
     idle: Notify,
     #[cfg(debug_assertions)]
     local_completion_barrier: std::sync::Mutex<Option<LocalCompletionBarrier>>,
+}
+
+/// Bounds readiness work and records dependency health transitions per server.
+#[derive(Clone)]
+pub struct ReadinessTracker {
+    inner: Arc<ReadinessTrackerInner>,
+}
+
+struct ReadinessTrackerInner {
+    probe: Semaphore,
+    status: AtomicU8,
+}
+
+const READINESS_UNKNOWN: u8 = 0;
+const READINESS_READY: u8 = 1;
+const READINESS_NOT_READY: u8 = 2;
+
+/// Exclusive ownership of one dependency readiness probe.
+pub struct ReadinessProbe<'a> {
+    tracker: &'a ReadinessTracker,
+    _permit: SemaphorePermit<'a>,
+}
+
+impl Default for ReadinessTracker {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(ReadinessTrackerInner {
+                probe: Semaphore::new(1),
+                status: AtomicU8::new(READINESS_UNKNOWN),
+            }),
+        }
+    }
+}
+
+impl ReadinessTracker {
+    /// Start the only allowed in-flight dependency probe.
+    #[must_use]
+    pub fn try_start_probe(&self) -> Option<ReadinessProbe<'_>> {
+        let permit = self.inner.probe.try_acquire().ok()?;
+        Some(ReadinessProbe {
+            tracker: self,
+            _permit: permit,
+        })
+    }
+
+    /// Return the last completed dependency result, if any.
+    #[must_use]
+    pub fn last_result(&self) -> Option<bool> {
+        match self.inner.status.load(Ordering::Relaxed) {
+            READINESS_READY => Some(true),
+            READINESS_NOT_READY => Some(false),
+            _ => None,
+        }
+    }
+}
+
+impl ReadinessProbe<'_> {
+    /// Complete this probe and return whether dependency readiness changed.
+    #[must_use]
+    pub fn finish(self, ready: bool) -> bool {
+        let current = if ready { READINESS_READY } else { READINESS_NOT_READY };
+        self.tracker.inner.status.swap(current, Ordering::Relaxed) != current
+    }
 }
 
 #[cfg(debug_assertions)]
@@ -155,6 +218,10 @@ impl ServerConfig {
 pub struct AppState {
     pub proxy_state: ProxyState,
     pub exec_ctx: Arc<ExecutionContext>,
+    /// Dedicated no-redirect client for inference-service health probes.
+    pub llm_readiness_client: reqwest::Client,
+    /// Prevents public probes from multiplying dependency work and tracks transitions.
+    pub readiness_tracker: ReadinessTracker,
     /// Shared cancellation signal used to drain long-lived handlers.
     pub shutdown_token: CancellationToken,
     /// Tracks upgraded WebSocket tasks, which Axum does not await during HTTP drain.

--- a/crates/agentic-server/src/app.rs
+++ b/crates/agentic-server/src/app.rs
@@ -161,6 +161,8 @@ pub struct AppState {
     pub websocket_tracker: WebSocketTracker,
     /// vLLM base URL — used by the `/ready` health probe.
     pub llm_api_base: String,
+    /// Whether `/ready` should omit the upstream health check.
+    pub skip_llm_ready_check: bool,
     /// Server-configured API key; used as fallback when the request carries no
     /// `Authorization` header on the executor path.
     pub openai_api_key: Option<String>,

--- a/crates/agentic-server/src/handler/http/models.rs
+++ b/crates/agentic-server/src/handler/http/models.rs
@@ -8,6 +8,7 @@ use serde_json::{Value, json};
 use tracing::warn;
 
 use agentic_core::proxy::{ProxyBody, ProxyResponse, error_response, proxy_get};
+use agentic_core::readiness::{LlmReadiness, probe_llm_readiness};
 
 use super::super::common::convert_response;
 use crate::app::AppState;
@@ -106,31 +107,29 @@ pub async fn health() -> impl IntoResponse {
 }
 
 async fn upstream_is_ready(state: &AppState) -> bool {
-    let base = state.llm_api_base.trim_end_matches('/');
-    let url = format!("{base}/health");
-
-    let mut request = state.exec_ctx.client.get(&url);
-    if let Some(key) = state
-        .openai_api_key
-        .as_deref()
-        .map(str::trim)
-        .filter(|key| !key.is_empty())
+    match probe_llm_readiness(
+        &state.exec_ctx.client,
+        &state.llm_api_base,
+        state.openai_api_key.as_deref(),
+        std::time::Duration::from_secs(2),
+    )
+    .await
     {
-        request = request.bearer_auth(key);
-    }
-
-    match tokio::time::timeout(std::time::Duration::from_secs(2), request.send()).await {
-        Ok(Ok(resp)) if resp.status().is_success() => true,
-        Ok(Ok(resp)) => {
-            warn!("LLM backend not ready: {}", resp.status());
+        Ok(LlmReadiness::Ready) => true,
+        Ok(LlmReadiness::Rejected(status)) => {
+            warn!("LLM backend not ready: {status}");
             false
         }
-        Ok(Err(e)) => {
-            warn!("LLM backend unreachable: {e}");
+        Ok(LlmReadiness::Unreachable(error)) => {
+            warn!("LLM backend unreachable: {error}");
             false
         }
-        Err(_) => {
+        Ok(LlmReadiness::TimedOut) => {
             warn!("LLM backend readiness check timed out");
+            false
+        }
+        Err(error) => {
+            warn!("LLM backend readiness configuration invalid: {error}");
             false
         }
     }
@@ -141,15 +140,33 @@ async fn configured_upstream_is_ready(state: &AppState) -> bool {
 }
 
 pub async fn ready(State(state): State<AppState>) -> impl IntoResponse {
-    let (storage_ready, upstream_ready) = tokio::join!(
-        state.exec_ctx.storage_ready(std::time::Duration::from_secs(1)),
-        configured_upstream_is_ready(&state)
-    );
-    if !storage_ready {
-        warn!("database persistence not ready");
-    }
+    let storage_ready = state.exec_ctx.storage_ready(std::time::Duration::from_secs(1));
+    let upstream_ready = configured_upstream_is_ready(&state);
+    tokio::pin!(storage_ready, upstream_ready);
 
-    if storage_ready && upstream_ready {
+    let dependencies_ready = tokio::select! {
+        storage_ready = &mut storage_ready => {
+            if storage_ready {
+                upstream_ready.await
+            } else {
+                warn!("database persistence not ready");
+                false
+            }
+        }
+        upstream_ready = &mut upstream_ready => {
+            if upstream_ready {
+                let storage_ready = storage_ready.await;
+                if !storage_ready {
+                    warn!("database persistence not ready");
+                }
+                storage_ready
+            } else {
+                false
+            }
+        }
+    };
+
+    if dependencies_ready {
         StatusCode::OK
     } else {
         StatusCode::SERVICE_UNAVAILABLE

--- a/crates/agentic-server/src/handler/http/models.rs
+++ b/crates/agentic-server/src/handler/http/models.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::sync::OnceLock;
 
 use axum::extract::{Query, State};
@@ -5,10 +6,10 @@ use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Response};
 use http::StatusCode;
 use serde_json::{Value, json};
-use tracing::warn;
+use tracing::{debug, info, warn};
 
 use agentic_core::proxy::{ProxyBody, ProxyResponse, error_response, proxy_get};
-use agentic_core::readiness::{LlmReadiness, probe_llm_readiness};
+use agentic_core::readiness::{LLM_READINESS_PROBE_TIMEOUT, LlmReadiness, probe_llm_readiness};
 
 use super::super::common::convert_response;
 use crate::app::AppState;
@@ -108,28 +109,32 @@ pub async fn health() -> impl IntoResponse {
 
 async fn upstream_is_ready(state: &AppState) -> bool {
     match probe_llm_readiness(
-        &state.exec_ctx.client,
+        &state.llm_readiness_client,
         &state.llm_api_base,
         state.openai_api_key.as_deref(),
-        std::time::Duration::from_secs(2),
+        LLM_READINESS_PROBE_TIMEOUT,
     )
     .await
     {
         Ok(LlmReadiness::Ready) => true,
         Ok(LlmReadiness::Rejected(status)) => {
-            warn!("LLM backend not ready: {status}");
+            debug!(http.status = %status, "LLM backend not ready");
             false
         }
         Ok(LlmReadiness::Unreachable(error)) => {
-            warn!("LLM backend unreachable: {error}");
+            debug!(error = ?error, "LLM backend unreachable");
             false
         }
         Ok(LlmReadiness::TimedOut) => {
-            warn!("LLM backend readiness check timed out");
+            debug!("LLM backend readiness check timed out");
+            false
+        }
+        Ok(_) => {
+            debug!("LLM backend returned an unsupported readiness state");
             false
         }
         Err(error) => {
-            warn!("LLM backend readiness configuration invalid: {error}");
+            debug!(error = ?error, "LLM backend readiness configuration invalid");
             false
         }
     }
@@ -139,17 +144,18 @@ async fn configured_upstream_is_ready(state: &AppState) -> bool {
     state.skip_llm_ready_check || upstream_is_ready(state).await
 }
 
-pub async fn ready(State(state): State<AppState>) -> impl IntoResponse {
-    let storage_ready = state.exec_ctx.storage_ready(std::time::Duration::from_secs(1));
-    let upstream_ready = configured_upstream_is_ready(&state);
+async fn dependencies_are_ready(
+    storage_ready: impl Future<Output = bool>,
+    upstream_ready: impl Future<Output = bool>,
+) -> bool {
     tokio::pin!(storage_ready, upstream_ready);
 
-    let dependencies_ready = tokio::select! {
+    tokio::select! {
         storage_ready = &mut storage_ready => {
             if storage_ready {
                 upstream_ready.await
             } else {
-                warn!("database persistence not ready");
+                debug!("database persistence not ready");
                 false
             }
         }
@@ -157,14 +163,42 @@ pub async fn ready(State(state): State<AppState>) -> impl IntoResponse {
             if upstream_ready {
                 let storage_ready = storage_ready.await;
                 if !storage_ready {
-                    warn!("database persistence not ready");
+                    debug!("database persistence not ready");
                 }
                 storage_ready
             } else {
                 false
             }
         }
+    }
+}
+
+pub async fn ready(State(state): State<AppState>) -> impl IntoResponse {
+    let Some(probe) = state.readiness_tracker.try_start_probe() else {
+        let cached_ready = state.readiness_tracker.last_result().unwrap_or(false);
+        debug!(
+            readiness.ready = cached_ready,
+            "returning cached readiness while dependency probe is in progress"
+        );
+        return if cached_ready {
+            StatusCode::OK
+        } else {
+            StatusCode::SERVICE_UNAVAILABLE
+        };
     };
+    let dependencies_ready = dependencies_are_ready(
+        state.exec_ctx.storage_ready(std::time::Duration::from_secs(1)),
+        configured_upstream_is_ready(&state),
+    )
+    .await;
+
+    if probe.finish(dependencies_ready) {
+        if dependencies_ready {
+            info!(readiness.ready = true, "gateway dependencies ready");
+        } else {
+            warn!(readiness.ready = false, "gateway dependencies not ready");
+        }
+    }
 
     if dependencies_ready {
         StatusCode::OK
@@ -211,4 +245,52 @@ pub async fn models(State(state): State<AppState>, headers: HeaderMap, Query(par
     }
 
     axum::Json(build_codex_models_response(&upstream_bytes)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future;
+    use std::time::Duration;
+
+    use super::dependencies_are_ready;
+    use crate::app::ReadinessTracker;
+
+    #[test]
+    fn readiness_tracker_reports_only_state_transitions() {
+        let tracker = ReadinessTracker::default();
+
+        assert_eq!(tracker.last_result(), None);
+        assert!(tracker.try_start_probe().unwrap().finish(false));
+        assert_eq!(tracker.last_result(), Some(false));
+        assert!(!tracker.try_start_probe().unwrap().finish(false));
+        assert!(tracker.try_start_probe().unwrap().finish(true));
+        assert_eq!(tracker.last_result(), Some(true));
+        assert!(!tracker.try_start_probe().unwrap().finish(true));
+        assert!(tracker.try_start_probe().unwrap().finish(false));
+        assert_eq!(tracker.last_result(), Some(false));
+    }
+
+    #[test]
+    fn unfinished_readiness_probe_releases_permit_without_changing_result() {
+        let tracker = ReadinessTracker::default();
+        assert!(tracker.try_start_probe().unwrap().finish(true));
+
+        let unfinished = tracker.try_start_probe().unwrap();
+        drop(unfinished);
+
+        assert_eq!(tracker.last_result(), Some(true));
+        assert!(tracker.try_start_probe().is_some());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dependency_check_fails_fast_when_upstream_is_unready() {
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            dependencies_are_ready(future::pending(), future::ready(false)),
+        )
+        .await
+        .expect("upstream failure must win before the pending storage check");
+
+        assert!(!result);
+    }
 }

--- a/crates/agentic-server/src/handler/http/models.rs
+++ b/crates/agentic-server/src/handler/http/models.rs
@@ -105,32 +105,54 @@ pub async fn health() -> impl IntoResponse {
     StatusCode::OK
 }
 
-pub async fn ready(State(state): State<AppState>) -> impl IntoResponse {
-    if !state.exec_ctx.storage_ready(std::time::Duration::from_secs(1)).await {
-        warn!("database persistence not ready");
-        return StatusCode::SERVICE_UNAVAILABLE;
-    }
-
+async fn upstream_is_ready(state: &AppState) -> bool {
     let base = state.llm_api_base.trim_end_matches('/');
     let url = format!("{base}/health");
 
-    match state
-        .exec_ctx
-        .client
-        .get(&url)
-        .timeout(std::time::Duration::from_secs(2))
-        .send()
-        .await
+    let mut request = state.exec_ctx.client.get(&url);
+    if let Some(key) = state
+        .openai_api_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
     {
-        Ok(resp) if resp.status().is_success() => StatusCode::OK,
-        Ok(resp) => {
+        request = request.bearer_auth(key);
+    }
+
+    match tokio::time::timeout(std::time::Duration::from_secs(2), request.send()).await {
+        Ok(Ok(resp)) if resp.status().is_success() => true,
+        Ok(Ok(resp)) => {
             warn!("LLM backend not ready: {}", resp.status());
-            StatusCode::SERVICE_UNAVAILABLE
+            false
         }
-        Err(e) => {
+        Ok(Err(e)) => {
             warn!("LLM backend unreachable: {e}");
-            StatusCode::SERVICE_UNAVAILABLE
+            false
         }
+        Err(_) => {
+            warn!("LLM backend readiness check timed out");
+            false
+        }
+    }
+}
+
+async fn configured_upstream_is_ready(state: &AppState) -> bool {
+    state.skip_llm_ready_check || upstream_is_ready(state).await
+}
+
+pub async fn ready(State(state): State<AppState>) -> impl IntoResponse {
+    let (storage_ready, upstream_ready) = tokio::join!(
+        state.exec_ctx.storage_ready(std::time::Duration::from_secs(1)),
+        configured_upstream_is_ready(&state)
+    );
+    if !storage_ready {
+        warn!("database persistence not ready");
+    }
+
+    if storage_ready && upstream_ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
     }
 }
 

--- a/crates/agentic-server/src/server.rs
+++ b/crates/agentic-server/src/server.rs
@@ -42,6 +42,7 @@ async fn build_state(config: &Config, shutdown_token: CancellationToken) -> Resu
         shutdown_token,
         websocket_tracker: WebSocketTracker::default(),
         llm_api_base: config.llm_api_base.clone(),
+        skip_llm_ready_check: config.skip_llm_ready_check,
         openai_api_key: config.openai_api_key.clone(),
     })
 }

--- a/crates/agentic-server/src/server.rs
+++ b/crates/agentic-server/src/server.rs
@@ -7,8 +7,8 @@ use agentic_core::config::Config;
 use agentic_core::error::Error as CoreError;
 use agentic_core::executor::ExecutionContext;
 use agentic_core::proxy::ProxyState;
-use agentic_core::readiness::wait_llm_ready;
-use agentic_server::app::{AppState, ServerConfig, WebSocketTracker, build_router_with_auth};
+use agentic_core::readiness::{llm_readiness_client, wait_llm_ready};
+use agentic_server::app::{AppState, ReadinessTracker, ServerConfig, WebSocketTracker, build_router_with_auth};
 use agentic_server::auth::{OidcAuthError, OidcAuthenticator, OidcConfig};
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
@@ -39,6 +39,8 @@ async fn build_state(config: &Config, shutdown_token: CancellationToken) -> Resu
     Ok(AppState {
         proxy_state,
         exec_ctx,
+        llm_readiness_client: llm_readiness_client()?,
+        readiness_tracker: ReadinessTracker::default(),
         shutdown_token,
         websocket_tracker: WebSocketTracker::default(),
         llm_api_base: config.llm_api_base.clone(),

--- a/crates/agentic-server/tests/common/mod.rs
+++ b/crates/agentic-server/tests/common/mod.rs
@@ -10,8 +10,9 @@ use tokio_util::sync::CancellationToken;
 use agentic_core::config::Config;
 use agentic_core::executor::{ConversationHandler, ExecutionContext, ResponseHandler};
 use agentic_core::proxy::ProxyState;
+use agentic_core::readiness::llm_readiness_client;
 use agentic_core::storage::{ConversationStore, ResponseStore};
-use agentic_server::app::{AppState, ServerConfig, WebSocketTracker, build_router};
+use agentic_server::app::{AppState, ReadinessTracker, ServerConfig, WebSocketTracker, build_router};
 
 pub fn test_config(llm_url: &str) -> Config {
     Config {
@@ -38,6 +39,8 @@ pub fn test_state(config: &Config) -> AppState {
     AppState {
         proxy_state,
         exec_ctx,
+        llm_readiness_client: llm_readiness_client().expect("readiness client"),
+        readiness_tracker: ReadinessTracker::default(),
         shutdown_token: CancellationToken::new(),
         websocket_tracker: WebSocketTracker::default(),
         llm_api_base: config.llm_api_base.clone(),

--- a/crates/agentic-server/tests/common/mod.rs
+++ b/crates/agentic-server/tests/common/mod.rs
@@ -41,6 +41,7 @@ pub fn test_state(config: &Config) -> AppState {
         shutdown_token: CancellationToken::new(),
         websocket_tracker: WebSocketTracker::default(),
         llm_api_base: config.llm_api_base.clone(),
+        skip_llm_ready_check: config.skip_llm_ready_check,
         openai_api_key: config.openai_api_key.clone(),
     }
 }

--- a/crates/agentic-server/tests/health_test.rs
+++ b/crates/agentic-server/tests/health_test.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use agentic_core::config::Config;
 use agentic_core::executor::ExecutionContext;
@@ -56,6 +57,48 @@ async fn test_ready_returns_503_when_llm_unreachable() {
 }
 
 #[tokio::test]
+async fn test_ready_returns_503_when_llm_rejects_health_check() {
+    let app = Router::new().route("/health", get(|| async { StatusCode::UNAUTHORIZED }));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let upstream = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let (gw_url, gateway) = spawn_gateway(test_state(&test_config_no_key(&format!("http://{addr}")))).await;
+
+    let resp = reqwest::get(format!("{gw_url}/ready")).await.unwrap();
+
+    assert_eq!(resp.status(), 503);
+    upstream.abort();
+    gateway.abort();
+}
+
+#[tokio::test]
+async fn test_ready_returns_503_when_llm_health_check_times_out() {
+    let app = Router::new().route(
+        "/health",
+        get(|| async {
+            std::future::pending::<()>().await;
+            StatusCode::OK
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let upstream = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let (gw_url, gateway) = spawn_gateway(test_state(&test_config_no_key(&format!("http://{addr}")))).await;
+
+    let response = tokio::time::timeout(
+        std::time::Duration::from_secs(3),
+        reqwest::get(format!("{gw_url}/ready")),
+    )
+    .await
+    .expect("readiness response must respect the two-second upstream timeout")
+    .unwrap();
+
+    assert_eq!(response.status(), 503);
+    upstream.abort();
+    gateway.abort();
+}
+
+#[tokio::test]
 async fn test_ready_returns_503_when_database_pool_is_exhausted() {
     let (llm_url, _h1) = spawn_mock_llm().await;
     let mut config = test_config(&llm_url);
@@ -82,19 +125,106 @@ async fn test_ready_returns_503_when_database_pool_is_exhausted() {
 }
 
 #[tokio::test]
-async fn test_ready_skips_upstream_when_configured() {
+async fn test_ready_fails_fast_when_database_is_unready() {
+    let app = Router::new().route(
+        "/health",
+        get(|| async {
+            std::future::pending::<()>().await;
+            StatusCode::OK
+        }),
+    );
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let dead_addr = listener.local_addr().unwrap();
-    drop(listener);
+    let addr = listener.local_addr().unwrap();
+    let upstream = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let mut config = test_config_no_key(&format!("http://{addr}"));
+    config.db_url = Some("sqlite://?mode=memory".to_owned());
+    let exec_ctx = Arc::new(
+        ExecutionContext::from_config(&config)
+            .await
+            .expect("create execution context"),
+    );
+    let held_connection = exec_ctx
+        .storage_pool()
+        .expect("configured storage pool")
+        .acquire()
+        .await
+        .expect("hold only database connection");
+    let mut state = test_state(&config);
+    state.exec_ctx = exec_ctx;
+    let (gw_url, gateway) = spawn_gateway(state).await;
+
+    let response = tokio::time::timeout(
+        std::time::Duration::from_millis(1_500),
+        reqwest::get(format!("{gw_url}/ready")),
+    )
+    .await
+    .expect("database failure should not wait for the upstream timeout")
+    .unwrap();
+
+    assert_eq!(response.status(), 503);
+    drop(held_connection);
+    upstream.abort();
+    gateway.abort();
+}
+
+#[tokio::test]
+async fn test_ready_skips_upstream_when_configured() {
+    let requests = Arc::new(AtomicUsize::new(0));
+    let app = Router::new().route(
+        "/health",
+        get({
+            let requests = Arc::clone(&requests);
+            move || {
+                let requests = Arc::clone(&requests);
+                async move {
+                    requests.fetch_add(1, Ordering::SeqCst);
+                    StatusCode::OK
+                }
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let upstream = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
     let config = Config {
         skip_llm_ready_check: true,
-        ..test_config_no_key(&format!("http://{dead_addr}"))
+        ..test_config_no_key(&format!("http://{addr}"))
     };
-    let (gw_url, _gateway) = spawn_gateway(test_state(&config)).await;
+    let (gw_url, gateway) = spawn_gateway(test_state(&config)).await;
 
     let resp = reqwest::get(format!("{gw_url}/ready")).await.unwrap();
 
     assert_eq!(resp.status(), 200);
+    assert_eq!(requests.load(Ordering::SeqCst), 0);
+    upstream.abort();
+    gateway.abort();
+}
+
+#[tokio::test]
+async fn test_ready_skip_still_requires_database() {
+    let mut config = test_config("http://127.0.0.1:1");
+    config.skip_llm_ready_check = true;
+    config.db_url = Some("sqlite://?mode=memory".to_owned());
+    let exec_ctx = Arc::new(
+        ExecutionContext::from_config(&config)
+            .await
+            .expect("create execution context"),
+    );
+    let held_connection = exec_ctx
+        .storage_pool()
+        .expect("configured storage pool")
+        .acquire()
+        .await
+        .expect("hold only database connection");
+    let mut state = test_state(&config);
+    state.exec_ctx = exec_ctx;
+    let (gw_url, gateway) = spawn_gateway(state).await;
+
+    let resp = reqwest::get(format!("{gw_url}/ready")).await.unwrap();
+
+    assert_eq!(resp.status(), 503);
+    drop(held_connection);
+    gateway.abort();
 }
 
 #[tokio::test]

--- a/crates/agentic-server/tests/health_test.rs
+++ b/crates/agentic-server/tests/health_test.rs
@@ -4,7 +4,13 @@ use std::sync::Arc;
 
 use agentic_core::config::Config;
 use agentic_core::executor::ExecutionContext;
+use axum::Router;
+use axum::http::HeaderMap;
+use axum::response::IntoResponse;
+use axum::routing::get;
 use common::{spawn_gateway, spawn_mock_llm, test_config, test_state};
+use http::StatusCode;
+use tokio::net::TcpListener;
 
 fn test_config_no_key(llm_url: &str) -> Config {
     Config {
@@ -73,4 +79,44 @@ async fn test_ready_returns_503_when_database_pool_is_exhausted() {
 
     assert_eq!(resp.status(), 503);
     drop(held_connection);
+}
+
+#[tokio::test]
+async fn test_ready_skips_upstream_when_configured() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let dead_addr = listener.local_addr().unwrap();
+    drop(listener);
+    let config = Config {
+        skip_llm_ready_check: true,
+        ..test_config_no_key(&format!("http://{dead_addr}"))
+    };
+    let (gw_url, _gateway) = spawn_gateway(test_state(&config)).await;
+
+    let resp = reqwest::get(format!("{gw_url}/ready")).await.unwrap();
+
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn test_ready_authenticates_upstream_health_check() {
+    let app = Router::new().route(
+        "/health",
+        get(|headers: HeaderMap| async move {
+            if headers.get("authorization").and_then(|value| value.to_str().ok()) == Some("Bearer test-key") {
+                StatusCode::OK.into_response()
+            } else {
+                StatusCode::UNAUTHORIZED.into_response()
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let upstream = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let (gw_url, gateway) = spawn_gateway(test_state(&test_config(&format!("http://{addr}")))).await;
+    let resp = reqwest::get(format!("{gw_url}/ready")).await.unwrap();
+
+    assert_eq!(resp.status(), 200);
+    upstream.abort();
+    gateway.abort();
 }

--- a/crates/agentic-server/tests/health_test.rs
+++ b/crates/agentic-server/tests/health_test.rs
@@ -72,6 +72,21 @@ async fn test_ready_returns_503_when_llm_rejects_health_check() {
 }
 
 #[tokio::test]
+async fn test_ready_accepts_any_successful_llm_health_status() {
+    let app = Router::new().route("/health", get(|| async { StatusCode::NO_CONTENT }));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let upstream = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let (gw_url, gateway) = spawn_gateway(test_state(&test_config_no_key(&format!("http://{addr}")))).await;
+
+    let resp = reqwest::get(format!("{gw_url}/ready")).await.unwrap();
+
+    assert_eq!(resp.status(), 200);
+    upstream.abort();
+    gateway.abort();
+}
+
+#[tokio::test]
 async fn test_ready_returns_503_when_llm_health_check_times_out() {
     let app = Router::new().route(
         "/health",

--- a/crates/agentic-server/tests/health_test.rs
+++ b/crates/agentic-server/tests/health_test.rs
@@ -7,7 +7,7 @@ use agentic_core::config::Config;
 use agentic_core::executor::ExecutionContext;
 use axum::Router;
 use axum::http::HeaderMap;
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Redirect};
 use axum::routing::get;
 use common::{spawn_gateway, spawn_mock_llm, test_config, test_state};
 use http::StatusCode;
@@ -18,6 +18,24 @@ fn test_config_no_key(llm_url: &str) -> Config {
         openai_api_key: None,
         ..test_config(llm_url)
     }
+}
+
+async fn spawn_upstream(app: Router) -> (String, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let upstream = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (format!("http://{addr}"), upstream)
+}
+
+async fn spawn_gateway_for_upstream(
+    app: Router,
+    configure: impl FnOnce(&mut Config),
+) -> (String, tokio::task::JoinHandle<()>, tokio::task::JoinHandle<()>) {
+    let (upstream_url, upstream) = spawn_upstream(app).await;
+    let mut config = test_config_no_key(&upstream_url);
+    configure(&mut config);
+    let (gateway_url, gateway) = spawn_gateway(test_state(&config)).await;
+    (gateway_url, upstream, gateway)
 }
 
 #[tokio::test]
@@ -59,10 +77,7 @@ async fn test_ready_returns_503_when_llm_unreachable() {
 #[tokio::test]
 async fn test_ready_returns_503_when_llm_rejects_health_check() {
     let app = Router::new().route("/health", get(|| async { StatusCode::UNAUTHORIZED }));
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    let upstream = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-    let (gw_url, gateway) = spawn_gateway(test_state(&test_config_no_key(&format!("http://{addr}")))).await;
+    let (gw_url, upstream, gateway) = spawn_gateway_for_upstream(app, |_| {}).await;
 
     let resp = reqwest::get(format!("{gw_url}/ready")).await.unwrap();
 
@@ -72,12 +87,23 @@ async fn test_ready_returns_503_when_llm_rejects_health_check() {
 }
 
 #[tokio::test]
+async fn test_ready_returns_503_when_llm_health_redirects_to_success() {
+    let app = Router::new()
+        .route("/health", get(|| async { Redirect::temporary("/login") }))
+        .route("/login", get(|| async { StatusCode::OK }));
+    let (gw_url, upstream, gateway) = spawn_gateway_for_upstream(app, |_| {}).await;
+
+    let response = reqwest::get(format!("{gw_url}/ready")).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    upstream.abort();
+    gateway.abort();
+}
+
+#[tokio::test]
 async fn test_ready_accepts_any_successful_llm_health_status() {
     let app = Router::new().route("/health", get(|| async { StatusCode::NO_CONTENT }));
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    let upstream = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-    let (gw_url, gateway) = spawn_gateway(test_state(&test_config_no_key(&format!("http://{addr}")))).await;
+    let (gw_url, upstream, gateway) = spawn_gateway_for_upstream(app, |_| {}).await;
 
     let resp = reqwest::get(format!("{gw_url}/ready")).await.unwrap();
 
@@ -95,10 +121,7 @@ async fn test_ready_returns_503_when_llm_health_check_times_out() {
             StatusCode::OK
         }),
     );
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    let upstream = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-    let (gw_url, gateway) = spawn_gateway(test_state(&test_config_no_key(&format!("http://{addr}")))).await;
+    let (gw_url, upstream, gateway) = spawn_gateway_for_upstream(app, |_| {}).await;
 
     let response = tokio::time::timeout(
         std::time::Duration::from_secs(3),
@@ -111,6 +134,48 @@ async fn test_ready_returns_503_when_llm_health_check_times_out() {
     assert_eq!(response.status(), 503);
     upstream.abort();
     gateway.abort();
+}
+
+#[tokio::test]
+async fn test_ready_returns_cached_result_during_overlapping_dependency_probe() {
+    for (cached, expected) in [
+        (None, StatusCode::SERVICE_UNAVAILABLE),
+        (Some(false), StatusCode::SERVICE_UNAVAILABLE),
+        (Some(true), StatusCode::OK),
+    ] {
+        let requests = Arc::new(AtomicUsize::new(0));
+        let app = Router::new().route(
+            "/health",
+            get({
+                let requests = Arc::clone(&requests);
+                move || {
+                    let requests = Arc::clone(&requests);
+                    async move {
+                        requests.fetch_add(1, Ordering::SeqCst);
+                        StatusCode::OK
+                    }
+                }
+            }),
+        );
+        let (llm_url, upstream) = spawn_upstream(app).await;
+        let state = test_state(&test_config_no_key(&llm_url));
+        let readiness_tracker = state.readiness_tracker.clone();
+        if let Some(cached) = cached {
+            assert!(readiness_tracker.try_start_probe().unwrap().finish(cached));
+        }
+        let active_probe = readiness_tracker
+            .try_start_probe()
+            .expect("reserve the only readiness probe permit");
+        let (gw_url, gateway) = spawn_gateway(state).await;
+
+        let response = reqwest::get(format!("{gw_url}/ready")).await.unwrap();
+
+        assert_eq!(response.status(), expected);
+        assert_eq!(requests.load(Ordering::SeqCst), 0);
+        drop(active_probe);
+        upstream.abort();
+        gateway.abort();
+    }
 }
 
 #[tokio::test]
@@ -148,10 +213,8 @@ async fn test_ready_fails_fast_when_database_is_unready() {
             StatusCode::OK
         }),
     );
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    let upstream = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-    let mut config = test_config_no_key(&format!("http://{addr}"));
+    let (upstream_url, upstream) = spawn_upstream(app).await;
+    let mut config = test_config_no_key(&upstream_url);
     config.db_url = Some("sqlite://?mode=memory".to_owned());
     let exec_ctx = Arc::new(
         ExecutionContext::from_config(&config)
@@ -198,14 +261,10 @@ async fn test_ready_skips_upstream_when_configured() {
             }
         }),
     );
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    let upstream = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-    let config = Config {
-        skip_llm_ready_check: true,
-        ..test_config_no_key(&format!("http://{addr}"))
-    };
-    let (gw_url, gateway) = spawn_gateway(test_state(&config)).await;
+    let (gw_url, upstream, gateway) = spawn_gateway_for_upstream(app, |config| {
+        config.skip_llm_ready_check = true;
+    })
+    .await;
 
     let resp = reqwest::get(format!("{gw_url}/ready")).await.unwrap();
 
@@ -254,11 +313,10 @@ async fn test_ready_authenticates_upstream_health_check() {
             }
         }),
     );
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    let upstream = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-
-    let (gw_url, gateway) = spawn_gateway(test_state(&test_config(&format!("http://{addr}")))).await;
+    let (gw_url, upstream, gateway) = spawn_gateway_for_upstream(app, |config| {
+        config.openai_api_key = Some("test-key".to_owned());
+    })
+    .await;
     let resp = reqwest::get(format!("{gw_url}/ready")).await.unwrap();
 
     assert_eq!(resp.status(), 200);

--- a/crates/agentic-server/tests/kubernetes_manifests_test.rs
+++ b/crates/agentic-server/tests/kubernetes_manifests_test.rs
@@ -33,6 +33,14 @@ fn string_list(value: &Value) -> Vec<&str> {
         .collect()
 }
 
+fn assert_string_map_is_subset(selector: &Value, labels: &Value) {
+    let selector = selector.as_mapping().expect("selector must be a mapping");
+    let labels = labels.as_mapping().expect("labels must be a mapping");
+    for (key, value) in selector {
+        assert_eq!(labels.get(key), Some(value), "selector entry must match pod labels");
+    }
+}
+
 #[test]
 fn kustomization_includes_only_non_secret_base_resources() {
     let manifest = parse_manifest("kustomization.yaml");
@@ -167,12 +175,13 @@ fn deployment_is_replicated_hardened_and_probe_driven() {
 
 #[test]
 fn service_config_and_disruption_budget_match_the_workload() {
+    let deployment = parse_manifest("deployment.yaml");
+    let workload_selector = &deployment["spec"]["selector"]["matchLabels"];
+    let pod_labels = &deployment["spec"]["template"]["metadata"]["labels"];
     let service = parse_manifest("service.yaml");
     assert_eq!(service["spec"]["type"].as_str(), Some("ClusterIP"));
-    assert_eq!(
-        service["spec"]["selector"]["app.kubernetes.io/name"].as_str(),
-        Some("agentic-api")
-    );
+    assert_eq!(&service["spec"]["selector"], workload_selector);
+    assert_string_map_is_subset(&service["spec"]["selector"], pod_labels);
     assert_eq!(service["spec"]["ports"][0]["targetPort"].as_str(), Some("http"));
 
     let config = parse_manifest("configmap.yaml");
@@ -195,10 +204,8 @@ fn service_config_and_disruption_budget_match_the_workload() {
     let budget = parse_manifest("pod-disruption-budget.yaml");
     assert_eq!(budget["apiVersion"].as_str(), Some("policy/v1"));
     assert_eq!(budget["spec"]["minAvailable"].as_u64(), Some(1));
-    assert_eq!(
-        budget["spec"]["selector"]["matchLabels"]["app.kubernetes.io/name"].as_str(),
-        Some("agentic-api")
-    );
+    assert_eq!(&budget["spec"]["selector"]["matchLabels"], workload_selector);
+    assert_string_map_is_subset(&budget["spec"]["selector"]["matchLabels"], pod_labels);
 }
 
 #[test]
@@ -209,7 +216,7 @@ fn secret_example_documents_required_credentials() {
     assert!(
         secret["stringData"]["DATABASE_URL"]
             .as_str()
-            .is_some_and(|url| url.starts_with("postgresql://"))
+            .is_some_and(|url| url.starts_with("postgresql://") && url.contains("sslmode=verify-full"))
     );
     assert!(secret["stringData"]["OPENAI_API_KEY"].as_str().is_some());
 }
@@ -219,14 +226,17 @@ fn network_access_is_denied_by_default_and_ingress_is_opt_in() {
     let default_deny = parse_manifest("network-policy.yaml");
     assert_eq!(default_deny["apiVersion"].as_str(), Some("networking.k8s.io/v1"));
     assert_eq!(default_deny["kind"].as_str(), Some("NetworkPolicy"));
-    assert_eq!(
-        default_deny["spec"]["podSelector"]["matchLabels"]["app.kubernetes.io/name"].as_str(),
-        Some("agentic-api")
-    );
+    let deployment = parse_manifest("deployment.yaml");
+    let workload_selector = &deployment["spec"]["selector"]["matchLabels"];
+    let pod_labels = &deployment["spec"]["template"]["metadata"]["labels"];
+    assert_eq!(&default_deny["spec"]["podSelector"]["matchLabels"], workload_selector);
+    assert_string_map_is_subset(&default_deny["spec"]["podSelector"]["matchLabels"], pod_labels);
     assert_eq!(string_list(&default_deny["spec"]["policyTypes"]), ["Ingress"]);
     assert!(default_deny["spec"]["ingress"].as_sequence().is_some_and(Vec::is_empty));
 
     let ingress_access = parse_manifest("network-policy-ingress.example.yaml");
+    assert_eq!(&ingress_access["spec"]["podSelector"]["matchLabels"], workload_selector);
+    assert_string_map_is_subset(&ingress_access["spec"]["podSelector"]["matchLabels"], pod_labels);
     let ingress_rule = &ingress_access["spec"]["ingress"][0];
     assert_eq!(
         ingress_rule["from"][0]["namespaceSelector"]["matchLabels"]["kubernetes.io/metadata.name"].as_str(),

--- a/crates/agentic-server/tests/kubernetes_manifests_test.rs
+++ b/crates/agentic-server/tests/kubernetes_manifests_test.rs
@@ -78,6 +78,7 @@ fn deployment_is_replicated_hardened_and_probe_driven() {
         pod_spec["securityContext"]["seccompProfile"]["type"].as_str(),
         Some("RuntimeDefault")
     );
+    assert_eq!(pod_spec["securityContext"]["runAsNonRoot"].as_bool(), Some(true));
     assert!(pod_spec["securityContext"]["runAsUser"].is_null());
     assert_eq!(
         pod_spec["affinity"]["podAntiAffinity"]["preferredDuringSchedulingIgnoredDuringExecution"][0]
@@ -99,8 +100,8 @@ fn deployment_is_replicated_hardened_and_probe_driven() {
     assert!(
         manifest["spec"]["progressDeadlineSeconds"]
             .as_u64()
-            .is_some_and(|deadline| deadline > startup_budget_seconds),
-        "deployment progress deadline must exceed the startup probe budget"
+            .is_some_and(|deadline| deadline >= startup_budget_seconds + 300),
+        "deployment progress deadline must leave five minutes beyond the startup probe budget"
     );
     assert_eq!(
         container["envFrom"][0]["configMapRef"]["name"].as_str(),

--- a/crates/agentic-server/tests/kubernetes_manifests_test.rs
+++ b/crates/agentic-server/tests/kubernetes_manifests_test.rs
@@ -1,0 +1,239 @@
+use std::fs;
+use std::path::PathBuf;
+
+use serde_yml::Value;
+
+fn manifest_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../deploy/kubernetes")
+        .join(name)
+}
+
+fn parse_manifest(name: &str) -> Value {
+    let path = manifest_path(name);
+    let contents = fs::read_to_string(&path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    serde_yml::from_str(&contents).unwrap_or_else(|error| panic!("parse {}: {error}", path.display()))
+}
+
+fn named<'a>(values: &'a Value, name: &str) -> &'a Value {
+    values
+        .as_sequence()
+        .unwrap_or_else(|| panic!("expected sequence containing {name}"))
+        .iter()
+        .find(|value| value["name"].as_str() == Some(name))
+        .unwrap_or_else(|| panic!("missing entry named {name}"))
+}
+
+fn string_list(value: &Value) -> Vec<&str> {
+    value
+        .as_sequence()
+        .expect("expected string sequence")
+        .iter()
+        .map(|entry| entry.as_str().expect("expected string entry"))
+        .collect()
+}
+
+#[test]
+fn kustomization_includes_only_non_secret_base_resources() {
+    let manifest = parse_manifest("kustomization.yaml");
+    let resources = string_list(&manifest["resources"]);
+
+    assert_eq!(
+        resources,
+        [
+            "namespace.yaml",
+            "service-account.yaml",
+            "configmap.yaml",
+            "deployment.yaml",
+            "service.yaml",
+            "network-policy.yaml",
+            "pod-disruption-budget.yaml",
+        ]
+    );
+    assert!(!resources.contains(&"secret.example.yaml"));
+    assert!(!resources.contains(&"ingress.example.yaml"));
+    assert!(!resources.contains(&"network-policy-ingress.example.yaml"));
+}
+
+#[test]
+fn deployment_is_replicated_hardened_and_probe_driven() {
+    let manifest = parse_manifest("deployment.yaml");
+    assert_eq!(manifest["apiVersion"].as_str(), Some("apps/v1"));
+    assert_eq!(manifest["kind"].as_str(), Some("Deployment"));
+    assert_eq!(manifest["spec"]["replicas"].as_u64(), Some(2));
+    assert_eq!(
+        manifest["spec"]["strategy"]["rollingUpdate"]["maxUnavailable"].as_u64(),
+        Some(0)
+    );
+
+    let pod_spec = &manifest["spec"]["template"]["spec"];
+    assert_eq!(pod_spec["serviceAccountName"].as_str(), Some("agentic-api"));
+    assert_eq!(pod_spec["automountServiceAccountToken"].as_bool(), Some(false));
+    assert!(
+        pod_spec["terminationGracePeriodSeconds"]
+            .as_u64()
+            .is_some_and(|seconds| seconds >= 10)
+    );
+    assert_eq!(
+        pod_spec["securityContext"]["seccompProfile"]["type"].as_str(),
+        Some("RuntimeDefault")
+    );
+    assert!(pod_spec["securityContext"]["runAsUser"].is_null());
+    assert_eq!(
+        pod_spec["affinity"]["podAntiAffinity"]["preferredDuringSchedulingIgnoredDuringExecution"][0]
+            ["podAffinityTerm"]["topologyKey"]
+            .as_str(),
+        Some("kubernetes.io/hostname")
+    );
+
+    let container = named(&pod_spec["containers"], "agentic-api");
+    assert_eq!(string_list(&container["args"]), ["--llm-ready-timeout-s", "300"]);
+    assert_eq!(container["ports"][0]["name"].as_str(), Some("http"));
+    assert_eq!(container["ports"][0]["containerPort"].as_u64(), Some(9000));
+    let startup_budget_seconds = container["startupProbe"]["failureThreshold"]
+        .as_u64()
+        .zip(container["startupProbe"]["periodSeconds"].as_u64())
+        .map(|(failures, period)| failures * period)
+        .expect("startup probe must define a numeric failure threshold and period");
+    assert!(startup_budget_seconds > 600);
+    assert!(
+        manifest["spec"]["progressDeadlineSeconds"]
+            .as_u64()
+            .is_some_and(|deadline| deadline > startup_budget_seconds),
+        "deployment progress deadline must exceed the startup probe budget"
+    );
+    assert_eq!(
+        container["envFrom"][0]["configMapRef"]["name"].as_str(),
+        Some("agentic-api")
+    );
+
+    let database_url = named(&container["env"], "DATABASE_URL");
+    assert_eq!(
+        database_url["valueFrom"]["secretKeyRef"]["name"].as_str(),
+        Some("agentic-api")
+    );
+    assert_eq!(
+        database_url["valueFrom"]["secretKeyRef"]["key"].as_str(),
+        Some("DATABASE_URL")
+    );
+    assert_ne!(
+        database_url["valueFrom"]["secretKeyRef"]["optional"].as_bool(),
+        Some(true)
+    );
+
+    let openai_api_key = named(&container["env"], "OPENAI_API_KEY");
+    assert_eq!(
+        openai_api_key["valueFrom"]["secretKeyRef"]["optional"].as_bool(),
+        Some(true)
+    );
+
+    for (probe, path) in [
+        ("startupProbe", "/health"),
+        ("livenessProbe", "/health"),
+        ("readinessProbe", "/ready"),
+    ] {
+        assert_eq!(container[probe]["httpGet"]["path"].as_str(), Some(path));
+        assert_eq!(container[probe]["httpGet"]["port"].as_str(), Some("http"));
+        assert!(
+            container[probe]["timeoutSeconds"]
+                .as_u64()
+                .is_some_and(|seconds| seconds > 0)
+        );
+    }
+
+    assert_eq!(
+        container["securityContext"]["allowPrivilegeEscalation"].as_bool(),
+        Some(false)
+    );
+    assert_eq!(
+        container["securityContext"]["readOnlyRootFilesystem"].as_bool(),
+        Some(true)
+    );
+    assert_eq!(
+        container["securityContext"]["capabilities"]["drop"][0].as_str(),
+        Some("ALL")
+    );
+    assert_eq!(
+        string_list(&container["lifecycle"]["preStop"]["exec"]["command"]),
+        ["/bin/sh", "-c", "sleep 5"]
+    );
+
+    for class in ["requests", "limits"] {
+        assert!(container["resources"][class]["cpu"].is_string());
+        assert!(container["resources"][class]["memory"].is_string());
+    }
+}
+
+#[test]
+fn service_config_and_disruption_budget_match_the_workload() {
+    let service = parse_manifest("service.yaml");
+    assert_eq!(service["spec"]["type"].as_str(), Some("ClusterIP"));
+    assert_eq!(
+        service["spec"]["selector"]["app.kubernetes.io/name"].as_str(),
+        Some("agentic-api")
+    );
+    assert_eq!(service["spec"]["ports"][0]["targetPort"].as_str(), Some("http"));
+
+    let config = parse_manifest("configmap.yaml");
+    assert_eq!(config["data"]["GATEWAY_HOST"].as_str(), Some("0.0.0.0"));
+    assert_eq!(config["data"]["GATEWAY_PORT"].as_str(), Some("9000"));
+    assert_eq!(config["data"]["SKIP_LLM_READY_CHECK"].as_str(), Some("false"));
+    assert!(
+        config["data"]["CORS_ALLOWED_ORIGINS"]
+            .as_str()
+            .is_some_and(|origins| origins.starts_with("https://"))
+    );
+    assert!(
+        config["data"]["LLM_API_BASE"]
+            .as_str()
+            .is_some_and(|url| url.starts_with("https://"))
+    );
+    assert!(config["data"]["DATABASE_URL"].is_null());
+    assert!(config["data"]["OPENAI_API_KEY"].is_null());
+
+    let budget = parse_manifest("pod-disruption-budget.yaml");
+    assert_eq!(budget["apiVersion"].as_str(), Some("policy/v1"));
+    assert_eq!(budget["spec"]["minAvailable"].as_u64(), Some(1));
+    assert_eq!(
+        budget["spec"]["selector"]["matchLabels"]["app.kubernetes.io/name"].as_str(),
+        Some("agentic-api")
+    );
+}
+
+#[test]
+fn secret_example_documents_required_credentials() {
+    let secret = parse_manifest("secret.example.yaml");
+    assert_eq!(secret["kind"].as_str(), Some("Secret"));
+    assert_eq!(secret["metadata"]["name"].as_str(), Some("agentic-api"));
+    assert!(
+        secret["stringData"]["DATABASE_URL"]
+            .as_str()
+            .is_some_and(|url| url.starts_with("postgresql://"))
+    );
+    assert!(secret["stringData"]["OPENAI_API_KEY"].as_str().is_some());
+}
+
+#[test]
+fn network_access_is_denied_by_default_and_ingress_is_opt_in() {
+    let default_deny = parse_manifest("network-policy.yaml");
+    assert_eq!(default_deny["apiVersion"].as_str(), Some("networking.k8s.io/v1"));
+    assert_eq!(default_deny["kind"].as_str(), Some("NetworkPolicy"));
+    assert_eq!(
+        default_deny["spec"]["podSelector"]["matchLabels"]["app.kubernetes.io/name"].as_str(),
+        Some("agentic-api")
+    );
+    assert_eq!(string_list(&default_deny["spec"]["policyTypes"]), ["Ingress"]);
+    assert!(default_deny["spec"]["ingress"].as_sequence().is_some_and(Vec::is_empty));
+
+    let ingress_access = parse_manifest("network-policy-ingress.example.yaml");
+    let ingress_rule = &ingress_access["spec"]["ingress"][0];
+    assert_eq!(
+        ingress_rule["from"][0]["namespaceSelector"]["matchLabels"]["kubernetes.io/metadata.name"].as_str(),
+        Some("ingress-nginx")
+    );
+    assert_eq!(
+        ingress_rule["from"][0]["podSelector"]["matchLabels"]["app.kubernetes.io/name"].as_str(),
+        Some("ingress-nginx")
+    );
+    assert_eq!(ingress_rule["ports"][0]["port"].as_u64(), Some(9000));
+}

--- a/crates/agentic-server/tests/responses_test.rs
+++ b/crates/agentic-server/tests/responses_test.rs
@@ -206,6 +206,7 @@ async fn storage_backed_state(llm_url: &str) -> StorageBackedState {
         shutdown_token: CancellationToken::new(),
         websocket_tracker: WebSocketTracker::default(),
         llm_api_base: config.llm_api_base,
+        skip_llm_ready_check: config.skip_llm_ready_check,
         openai_api_key: config.openai_api_key,
     };
     StorageBackedState { state, pool, _db: db }

--- a/crates/agentic-server/tests/responses_test.rs
+++ b/crates/agentic-server/tests/responses_test.rs
@@ -203,6 +203,8 @@ async fn storage_backed_state(llm_url: &str) -> StorageBackedState {
     let state = AppState {
         proxy_state,
         exec_ctx,
+        llm_readiness_client: agentic_core::readiness::llm_readiness_client().expect("readiness client"),
+        readiness_tracker: agentic_server::app::ReadinessTracker::default(),
         shutdown_token: CancellationToken::new(),
         websocket_tracker: WebSocketTracker::default(),
         llm_api_base: config.llm_api_base,

--- a/crates/agentic-server/tests/responses_websocket_test.rs
+++ b/crates/agentic-server/tests/responses_websocket_test.rs
@@ -273,6 +273,8 @@ fn persistence_disabled_state(llm_url: &str) -> AppState {
     AppState {
         proxy_state,
         exec_ctx,
+        llm_readiness_client: agentic_core::readiness::llm_readiness_client().expect("readiness client"),
+        readiness_tracker: agentic_server::app::ReadinessTracker::default(),
         shutdown_token: CancellationToken::new(),
         websocket_tracker: WebSocketTracker::default(),
         llm_api_base: config.llm_api_base,
@@ -306,6 +308,8 @@ async fn storage_backed_state_with_web_search(llm_url: &str, web_search_base_url
     let state = AppState {
         proxy_state,
         exec_ctx,
+        llm_readiness_client: agentic_core::readiness::llm_readiness_client().expect("readiness client"),
+        readiness_tracker: agentic_server::app::ReadinessTracker::default(),
         shutdown_token: CancellationToken::new(),
         websocket_tracker: WebSocketTracker::default(),
         llm_api_base: config.llm_api_base,

--- a/crates/agentic-server/tests/responses_websocket_test.rs
+++ b/crates/agentic-server/tests/responses_websocket_test.rs
@@ -276,6 +276,7 @@ fn persistence_disabled_state(llm_url: &str) -> AppState {
         shutdown_token: CancellationToken::new(),
         websocket_tracker: WebSocketTracker::default(),
         llm_api_base: config.llm_api_base,
+        skip_llm_ready_check: config.skip_llm_ready_check,
         openai_api_key: config.openai_api_key,
     }
 }

--- a/crates/agentic-server/tests/responses_websocket_test.rs
+++ b/crates/agentic-server/tests/responses_websocket_test.rs
@@ -308,6 +308,7 @@ async fn storage_backed_state_with_web_search(llm_url: &str, web_search_base_url
         shutdown_token: CancellationToken::new(),
         websocket_tracker: WebSocketTracker::default(),
         llm_api_base: config.llm_api_base,
+        skip_llm_ready_check: config.skip_llm_ready_check,
         openai_api_key: config.openai_api_key,
     };
     StorageBackedState { state, pool, _db: db }

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agentic-api
+  labels:
+    app.kubernetes.io/name: agentic-api
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/part-of: agentic-api
+data:
+  GATEWAY_HOST: "0.0.0.0"
+  GATEWAY_PORT: "9000"
+  LLM_API_BASE: "https://vllm.example.com"
+  SKIP_LLM_READY_CHECK: "false"
+  CORS_ALLOWED_ORIGINS: "https://agentic-api.example.com"
+  RUST_LOG: "agentic_server=info,agentic_core=info"

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   replicas: 2
   revisionHistoryLimit: 3
-  progressDeadlineSeconds: 720
+  progressDeadlineSeconds: 960
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -1,0 +1,112 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentic-api
+  labels:
+    app.kubernetes.io/name: agentic-api
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/part-of: agentic-api
+spec:
+  replicas: 2
+  revisionHistoryLimit: 3
+  progressDeadlineSeconds: 720
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agentic-api
+      app.kubernetes.io/component: gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agentic-api
+        app.kubernetes.io/component: gateway
+        app.kubernetes.io/part-of: agentic-api
+    spec:
+      serviceAccountName: agentic-api
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: agentic-api
+                    app.kubernetes.io/component: gateway
+      containers:
+        - name: agentic-api
+          image: agentic-api:dev
+          imagePullPolicy: IfNotPresent
+          args:
+            - --llm-ready-timeout-s
+            - "300"
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: agentic-api
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: agentic-api
+                  key: DATABASE_URL
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: agentic-api
+                  key: OPENAI_API_KEY
+                  optional: true
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 132
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - sleep 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agentic-api
+resources:
+  - namespace.yaml
+  - service-account.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - network-policy.yaml
+  - pod-disruption-budget.yaml

--- a/deploy/kubernetes/namespace.yaml
+++ b/deploy/kubernetes/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agentic-api
+  labels:
+    app.kubernetes.io/name: agentic-api
+    app.kubernetes.io/part-of: agentic-api

--- a/deploy/kubernetes/network-policy-ingress.example.yaml
+++ b/deploy/kubernetes/network-policy-ingress.example.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: agentic-api-from-ingress
+  labels:
+    app.kubernetes.io/name: agentic-api
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/part-of: agentic-api
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: agentic-api
+      app.kubernetes.io/component: gateway
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 9000

--- a/deploy/kubernetes/network-policy.yaml
+++ b/deploy/kubernetes/network-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: agentic-api-default-deny
+  labels:
+    app.kubernetes.io/name: agentic-api
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/part-of: agentic-api
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: agentic-api
+      app.kubernetes.io/component: gateway
+  policyTypes:
+    - Ingress
+  ingress: []

--- a/deploy/kubernetes/pod-disruption-budget.yaml
+++ b/deploy/kubernetes/pod-disruption-budget.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: agentic-api
+  labels:
+    app.kubernetes.io/name: agentic-api
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/part-of: agentic-api
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agentic-api
+      app.kubernetes.io/component: gateway

--- a/deploy/kubernetes/secret.example.yaml
+++ b/deploy/kubernetes/secret.example.yaml
@@ -8,5 +8,5 @@ metadata:
     app.kubernetes.io/part-of: agentic-api
 type: Opaque
 stringData:
-  DATABASE_URL: "postgresql://agentic-api:replace-me@postgres.example.com:5432/agentic_api?sslmode=require"
+  DATABASE_URL: "postgresql://agentic-api:replace-me@postgres.example.com:5432/agentic_api?sslmode=verify-full"
   OPENAI_API_KEY: "replace-me"

--- a/deploy/kubernetes/secret.example.yaml
+++ b/deploy/kubernetes/secret.example.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agentic-api
+  labels:
+    app.kubernetes.io/name: agentic-api
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/part-of: agentic-api
+type: Opaque
+stringData:
+  DATABASE_URL: "postgresql://agentic-api:replace-me@postgres.example.com:5432/agentic_api?sslmode=require"
+  OPENAI_API_KEY: "replace-me"

--- a/deploy/kubernetes/service-account.yaml
+++ b/deploy/kubernetes/service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agentic-api
+  labels:
+    app.kubernetes.io/name: agentic-api
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/part-of: agentic-api
+automountServiceAccountToken: false

--- a/deploy/kubernetes/service.yaml
+++ b/deploy/kubernetes/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentic-api
+  labels:
+    app.kubernetes.io/name: agentic-api
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/part-of: agentic-api
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: agentic-api
+    app.kubernetes.io/component: gateway
+  ports:
+    - name: http
+      port: 9000
+      targetPort: http
+      protocol: TCP
+      appProtocol: http

--- a/docs/deploying/container.md
+++ b/docs/deploying/container.md
@@ -179,3 +179,6 @@ spec:
 ```
 
 Mount writable storage at `/var/lib/agentic-api` only when using SQLite. PostgreSQL deployments do not need a persistent filesystem for the gateway.
+
+For a replicated PostgreSQL deployment, use the
+[Kubernetes manifests and operational guide](kubernetes.md).

--- a/docs/deploying/container.md
+++ b/docs/deploying/container.md
@@ -39,7 +39,7 @@ The image starts `agentic-server` in standalone mode. At minimum, set `LLM_API_B
 | `OPENAI_API_KEY` | none | Credential sent to the upstream service when the client does not supply one |
 | `OIDC_ISSUER` | none | Optional OIDC issuer for inbound bearer-token authentication |
 | `OIDC_AUDIENCE` | none | Required token audience when `OIDC_ISSUER` is set |
-| `SKIP_LLM_READY_CHECK` | `false` | Skip the startup probe for hosted providers without `/health` |
+| `SKIP_LLM_READY_CHECK` | `false` | Skip startup and recurring upstream probes for providers without `/health`; PostgreSQL readiness remains enforced |
 | `CORS_ALLOWED_ORIGINS` | none | Comma-separated browser origins |
 
 The container entrypoint rejects percent-encoded SQLite paths because SQLx decodes them before opening the database. Use a literal filesystem path or PostgreSQL instead.

--- a/docs/deploying/kubernetes.md
+++ b/docs/deploying/kubernetes.md
@@ -1,0 +1,191 @@
+# Deploy agentic-api on Kubernetes
+
+The repository includes a Kustomize-compatible base in `deploy/kubernetes`. It runs two stateless gateway replicas
+against managed PostgreSQL and an external OpenAI-compatible inference service. The Service is `ClusterIP` because the
+gateway does not authenticate inbound callers yet. Put an authenticated application boundary in front of it before
+allowing traffic from outside the cluster.
+
+## Prepare the image and configuration
+
+Build and publish the production image described in the [container guide](container.md). The base uses
+`agentic-api:dev` so it also works with images loaded directly into a local cluster. Before deploying to a shared
+cluster, replace that image with an immutable registry digest in an environment-specific Kustomize overlay such as
+`deploy/kubernetes/overlays/production/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agentic-api
+resources:
+  - ../..
+images:
+  - name: agentic-api
+    newName: registry.example.com/vllm/agentic-api
+    digest: sha256:replace-with-the-published-digest
+```
+
+Change `LLM_API_BASE` and `CORS_ALLOWED_ORIGINS` in `deploy/kubernetes/configmap.yaml` or patch them in the same
+overlay. Keep `SKIP_LLM_READY_CHECK=false` when the inference service exposes `/health`. The recurring upstream check
+uses `OPENAI_API_KEY` as a bearer credential when configured. For a provider without `/health`, set
+`SKIP_LLM_READY_CHECK=true`; `/ready` will continue checking PostgreSQL but will omit the upstream check. Add a small
+Responses API request as an external monitor in that configuration.
+
+Create the namespace and Secret before applying the workload:
+
+```console
+kubectl apply -f deploy/kubernetes/namespace.yaml
+kubectl --namespace agentic-api create secret generic agentic-api \
+  --from-literal=DATABASE_URL='postgresql://agentic-api:replace-me@postgres.example.com:5432/agentic_api?sslmode=require' \
+  --from-literal=OPENAI_API_KEY='replace-me'
+```
+
+Omit `OPENAI_API_KEY` when the inference service does not require a fallback credential. The request's
+`Authorization` or Anthropic-compatible `x-api-key` header still takes precedence where the protocol requires it.
+`secret.example.yaml` documents the expected keys but is deliberately excluded from the Kustomize base. Do not add
+real credentials to that file or commit a generated Secret. Kubernetes Secrets are only base64-encoded by default;
+enable encryption at rest and restrict Secret access in the cluster.
+
+## Deploy and inspect the gateway
+
+Apply the base or the environment overlay:
+
+```console
+kubectl apply -k deploy/kubernetes
+kubectl --namespace agentic-api rollout status deployment/agentic-api
+kubectl --namespace agentic-api get pods,service,networkpolicy,poddisruptionbudget
+```
+
+ConfigMap and Secret values are injected as environment variables and do not update inside existing pods. After
+changing either object without otherwise changing the pod template, run
+`kubectl --namespace agentic-api rollout restart deployment/agentic-api` and wait for the rollout to finish.
+
+The base defines:
+
+- two gateway replicas with a rolling update that keeps the current replicas available;
+- a `ClusterIP` Service on port `9000`;
+- startup and liveness probes on `/health`, plus a readiness probe on `/ready`;
+- a 30-second pod termination grace period for endpoint propagation and the gateway's bounded eight-second drain;
+- CPU and memory requests and limits that should be tuned from observed traffic;
+- a preferred hostname anti-affinity rule for the two gateway replicas;
+- a non-root, read-only runtime with no Linux capabilities or mounted service-account token;
+- a default-deny ingress NetworkPolicy; and
+- a PodDisruptionBudget that retains one replica during voluntary disruption.
+
+The startup probe allows up to eleven minutes. The Deployment bounds the upstream startup wait at five minutes,
+leaving about six minutes for the database connection and embedded migrations before Kubernetes restarts the pod. The
+process does not bind its port until both steps succeed. `/health` then reports process liveness without depending on
+remote services. `/ready` runs bounded PostgreSQL and inference checks concurrently and removes a pod from Service
+endpoints when either required dependency fails.
+
+## Choose a migration policy
+
+By default, every new pod applies the embedded SQLx migrations before starting the HTTP server. PostgreSQL migration
+locking serializes concurrent migration attempts, and a failed migration keeps the pod out of service. Keep migrations
+backward-compatible with the previous gateway version so a rolling update can run old and new replicas together.
+
+For a supervisor-managed schema:
+
+1. apply the repository migrations in a release job before updating the Deployment;
+2. verify the target schema and any required compatibility upgrades;
+3. set `AGENTIC_API_SCHEMA_READY=1` in the gateway ConfigMap; and
+4. roll out the gateway only after the release job succeeds.
+
+The runtime image intentionally contains no shell database client, and the gateway has no migration-only command, so
+the base does not pretend to provide an in-image migration Job. Use a trusted database migration image or deployment
+controller. Never set `AGENTIC_API_SCHEMA_READY` merely to bypass a failed migration.
+
+## Put an authenticated edge in front
+
+Do not use `OPENAI_API_KEY` as a caller password. It is an upstream inference credential. Exposing the gateway directly
+would let anonymous callers spend that credential and read or write unscoped stored state.
+
+The repository deliberately does not include a ready-to-apply Ingress while inbound caller authentication remains
+deployment-specific. Create the Ingress in an environment overlay only after an identity-aware proxy or authenticated
+application service protects every `/v1/*` HTTP and WebSocket route. For ingress-nginx, configure external
+authentication and include settings equivalent to:
+
+```yaml
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: "https://auth.example.com/verify"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+```
+
+Use TLS and appropriate connection and request limits. The authentication boundary must consume and strip caller
+`Authorization` and `x-api-key` headers before forwarding to the gateway; otherwise the gateway treats them as
+upstream inference credentials instead of using its configured fallback. Use mTLS, a trusted non-forwarded identity
+mechanism, or another platform control between the edge and gateway until inbound and upstream credentials are
+separated in the gateway.
+
+The base NetworkPolicy denies all pod-network ingress to the gateway. When the authenticated boundary is an
+ingress-nginx controller, copy `network-policy-ingress.example.yaml` into the overlay with the authenticated Ingress.
+Its selectors
+admit only pods labeled `app.kubernetes.io/name=ingress-nginx` in the `ingress-nginx` namespace. Patch both selectors
+when the controller uses different labels or a different namespace. Keep the default-deny policy in place, and verify
+that the cluster's network plugin enforces NetworkPolicy before relying on it as a security boundary.
+
+The portable base does not restrict egress because the DNS resolver, managed PostgreSQL addresses, ports, and external
+inference destinations are environment-specific. Add a default-deny egress policy and explicit DNS, database, and
+inference allowances in the production overlay when the cluster's network plugin can express those destinations.
+
+SSE streams need buffering disabled from the client through every proxy. WebSocket clients should use `wss`, send
+keepalive pings, and reconnect with backoff after a rollout or node disruption. Stored continuation state is in
+PostgreSQL, so reconnects do not require session affinity; clients can continue with a conversation or previous
+response ID through any ready replica.
+
+Kubernetes begins endpoint removal at the same time as graceful pod termination. The five-second `preStop` delay gives
+controllers time to observe the terminating endpoint before `SIGTERM` reaches the gateway. The gateway then stops
+accepting new requests, drains active HTTP requests and WebSockets for up to eight seconds, and exits. The 30-second
+grace period includes both phases. Verify the external load balancer's endpoint propagation and retry behavior.
+
+Preferred anti-affinity encourages the scheduler to place replicas on different nodes without making a single-node
+development cluster unschedulable. Use hard topology-spread constraints across nodes or zones when production
+availability requires them. The PodDisruptionBudget only limits voluntary disruptions; it cannot prevent simultaneous
+loss of co-located replicas during a node failure.
+
+## Verify persistence and transport
+
+Reach the private Service through a temporary port-forward in a separate terminal:
+
+```console
+kubectl --namespace agentic-api port-forward service/agentic-api 9000:9000
+curl --fail http://127.0.0.1:9000/health
+curl --fail http://127.0.0.1:9000/ready
+```
+
+Send a stored Responses request, save its response ID, restart the Deployment, and continue with
+`previous_response_id`. A successful continuation after the rollout verifies that PostgreSQL, rather than a pod
+filesystem, owns the state:
+
+```console
+first_response_id=$(
+  curl --fail --silent --show-error http://127.0.0.1:9000/v1/responses \
+    --header "Content-Type: application/json" \
+    --data '{"model":"Qwen/Qwen3-30B-A3B-FP8","input":"Reply with READY","store":true}' |
+    jq --exit-status --raw-output .id
+)
+
+kubectl --namespace agentic-api rollout restart deployment/agentic-api
+kubectl --namespace agentic-api rollout status deployment/agentic-api
+```
+
+The port-forward exits when the selected pod terminates. Start the same `kubectl port-forward` command again after the
+rollout, then continue the request:
+
+```console
+curl --fail --silent --show-error http://127.0.0.1:9000/v1/responses \
+  --header "Content-Type: application/json" \
+  --data "$(jq --null-input --arg id "$first_response_id" '{
+    model: "Qwen/Qwen3-30B-A3B-FP8",
+    input: "What word did you return?",
+    previous_response_id: $id,
+    store: true
+  }')"
+```
+
+Repeat the check through the authenticated ingress for HTTP streaming and WebSockets before a production release.
+Size PostgreSQL pools, gateway replicas, and inference capacity together; adding gateway replicas cannot compensate
+for a saturated database or inference service.

--- a/docs/deploying/kubernetes.md
+++ b/docs/deploying/kubernetes.md
@@ -2,8 +2,8 @@
 
 The repository includes a Kustomize-compatible base in `deploy/kubernetes`. It runs two stateless gateway replicas
 against managed PostgreSQL and an external OpenAI-compatible inference service. The Service is `ClusterIP` because the
-gateway does not authenticate inbound callers yet. Put an authenticated application boundary in front of it before
-allowing traffic from outside the cluster.
+portable base does not choose an identity provider or expose an Ingress. Enable the gateway's native OIDC validation
+or put an authenticated application boundary in front of it before allowing traffic from outside the cluster.
 
 ## Prepare the image and configuration
 
@@ -73,15 +73,37 @@ The base defines:
 
 The startup probe allows up to eleven minutes. The Deployment bounds the upstream startup wait at five minutes,
 leaving about six minutes for the database connection and embedded migrations before Kubernetes restarts the pod. The
-process does not bind its port until both steps succeed. `/health` then reports process liveness without depending on
+sixteen-minute rollout progress deadline leaves another five minutes for scheduling and a cold image pull. The process
+does not bind its port until both startup steps succeed. `/health` then reports process liveness without depending on
 remote services. `/ready` runs bounded PostgreSQL and inference checks concurrently and removes a pod from Service
 endpoints when either required dependency fails.
+
+The base's CPU and memory requests are lower than its limits, so pods use Kubernetes' `Burstable` quality-of-service
+class and can be evicted before `Guaranteed` pods under node pressure. Tune both values from measurements; set requests
+equal to limits in a production overlay when eviction priority is more important than burst capacity.
 
 ## Choose a migration policy
 
 By default, every new pod applies the embedded SQLx migrations before starting the HTTP server. PostgreSQL migration
 locking serializes concurrent migration attempts, and a failed migration keeps the pod out of service. Keep migrations
 backward-compatible with the previous gateway version so a rolling update can run old and new replicas together.
+
+The first upgrade from a release that used 32-bit timestamp and sequence columns is an exception: do not use the base
+rolling strategy for that upgrade. Older replicas do not take the per-conversation row lock and can allocate duplicate
+sequence values while an upgraded replica is serving. During a maintenance window:
+
+1. stop or drain inbound writers, scale every older gateway replica to zero, and verify that no old pod remains;
+2. run the duplicate `(conversation_id, seq)` query in the
+   [PostgreSQL upgrade notes](container.md#postgresql-production-settings), resolving any rows according to the
+   deployment's data-retention policy;
+3. apply the compatibility migration with a dedicated migration role, or start exactly one upgraded replica and wait
+   for its embedded migration to finish;
+4. verify that the integer columns and unique conversation-sequence index are present; and
+5. start the upgraded Deployment, restore the desired replica count, and reopen inbound traffic only after `/ready`
+   succeeds.
+
+Ordinary rolling updates are appropriate only after every migration in the target release has been verified as
+expand/contract compatible with the previously deployed gateway.
 
 For a supervisor-managed schema:
 
@@ -94,15 +116,20 @@ The runtime image intentionally contains no shell database client, and the gatew
 the base does not pretend to provide an in-image migration Job. Use a trusted database migration image or deployment
 controller. Never set `AGENTIC_API_SCHEMA_READY` merely to bypass a failed migration.
 
-## Put an authenticated edge in front
+## Authenticate inbound callers
 
 Do not use `OPENAI_API_KEY` as a caller password. It is an upstream inference credential. Exposing the gateway directly
 would let anonymous callers spend that credential and read or write unscoped stored state.
 
-The repository deliberately does not include a ready-to-apply Ingress while inbound caller authentication remains
-deployment-specific. Create the Ingress in an environment overlay only after an identity-aware proxy or authenticated
-application service protects every `/v1/*` HTTP and WebSocket route. For ingress-nginx, configure external
-authentication and include settings equivalent to:
+The gateway can validate inbound OIDC bearer tokens itself. Add `OIDC_ISSUER` and `OIDC_AUDIENCE` to an
+environment-specific ConfigMap patch; both values are required together. The issuer must use HTTPS outside loopback
+development. Every `/v1/*` HTTP and WebSocket route then requires a valid bearer token, while `/health` and `/ready`
+remain available to Kubernetes probes. Follow the [OIDC validation contract](../design/oidc-bearer-authentication.md)
+and the [GitHub and Dex tutorial](github-oidc.md) when configuring the provider and clients.
+
+Alternatively, put an identity-aware proxy or authenticated application service in front of the gateway. In that
+mode, leave the gateway's OIDC variables unset and ensure the trusted edge protects every `/v1/*` HTTP and WebSocket
+route. For ingress-nginx, configure external authentication and include settings equivalent to:
 
 ```yaml
 metadata:
@@ -114,11 +141,11 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
 ```
 
-Use TLS and appropriate connection and request limits. The authentication boundary must consume and strip caller
-`Authorization` and `x-api-key` headers before forwarding to the gateway; otherwise the gateway treats them as
-upstream inference credentials instead of using its configured fallback. Use mTLS, a trusted non-forwarded identity
-mechanism, or another platform control between the edge and gateway until inbound and upstream credentials are
-separated in the gateway.
+Use TLS and appropriate connection and request limits. With external authentication, the boundary must consume and
+strip caller `Authorization` and `x-api-key` headers before forwarding to a gateway whose native OIDC validation is
+disabled; otherwise those values are treated as upstream inference credentials instead of using the configured
+fallback. Use mTLS or another platform control between the edge and gateway so only the trusted boundary can reach
+the Service.
 
 The base NetworkPolicy denies all pod-network ingress to the gateway. When the authenticated boundary is an
 ingress-nginx controller, copy `network-policy-ingress.example.yaml` into the overlay with the authenticated Ingress.
@@ -156,6 +183,10 @@ curl --fail http://127.0.0.1:9000/health
 curl --fail http://127.0.0.1:9000/ready
 ```
 
+The `/v1/*` examples below include an OIDC bearer header. When native OIDC validation is enabled, set `OIDC_TOKEN` to
+a valid ID token. When an external boundary supplies authentication instead, remove that header. Health and readiness
+requests do not require it.
+
 Send a stored Responses request, save its response ID, restart the Deployment, and continue with
 `previous_response_id`. A successful continuation after the rollout verifies that PostgreSQL, rather than a pod
 filesystem, owns the state:
@@ -163,6 +194,7 @@ filesystem, owns the state:
 ```console
 first_response_id=$(
   curl --fail --silent --show-error http://127.0.0.1:9000/v1/responses \
+    --header "Authorization: Bearer $OIDC_TOKEN" \
     --header "Content-Type: application/json" \
     --data '{"model":"Qwen/Qwen3-30B-A3B-FP8","input":"Reply with READY","store":true}' |
     jq --exit-status --raw-output .id
@@ -177,6 +209,7 @@ rollout, then continue the request:
 
 ```console
 curl --fail --silent --show-error http://127.0.0.1:9000/v1/responses \
+  --header "Authorization: Bearer $OIDC_TOKEN" \
   --header "Content-Type: application/json" \
   --data "$(jq --null-input --arg id "$first_response_id" '{
     model: "Qwen/Qwen3-30B-A3B-FP8",

--- a/docs/deploying/kubernetes.md
+++ b/docs/deploying/kubernetes.md
@@ -30,14 +30,22 @@ uses `OPENAI_API_KEY` as a bearer credential when configured. For a provider wit
 `SKIP_LLM_READY_CHECK=true`; `/ready` will continue checking PostgreSQL but will omit the upstream check. Add a small
 Responses API request as an external monitor in that configuration.
 
-Create the namespace and Secret before applying the workload:
+Create the namespace and Secret before applying the workload. Prefer an external secret manager in production. For a
+manual deployment, write the values to a mode-`0600` file outside the repository so credentials do not enter shell
+history or process arguments:
 
 ```console
 kubectl apply -f deploy/kubernetes/namespace.yaml
+install -m 600 /dev/null /tmp/agentic-api-secret.env
+$EDITOR /tmp/agentic-api-secret.env
 kubectl --namespace agentic-api create secret generic agentic-api \
-  --from-literal=DATABASE_URL='postgresql://agentic-api:replace-me@postgres.example.com:5432/agentic_api?sslmode=require' \
-  --from-literal=OPENAI_API_KEY='replace-me'
+  --from-env-file=/tmp/agentic-api-secret.env \
+  --dry-run=client --output=yaml |
+  kubectl apply --server-side --field-manager=agentic-api-operator --filename=-
 ```
+
+The protected file contains `DATABASE_URL=postgresql://...?...` and, when needed, `OPENAI_API_KEY=...`. Remove it
+securely after the Secret has been created.
 
 Omit `OPENAI_API_KEY` when the inference service does not require a fallback credential. The request's
 `Authorization` or Anthropic-compatible `x-api-key` header still takes precedence where the protocol requires it.
@@ -45,7 +53,23 @@ Omit `OPENAI_API_KEY` when the inference service does not require a fallback cre
 real credentials to that file or commit a generated Secret. Kubernetes Secrets are only base64-encoded by default;
 enable encryption at rest and restrict Secret access in the cluster.
 
+The PostgreSQL example requires TLS certificate and hostname verification. When the database uses a private CA, append
+`&sslrootcert=/path/to/postgres-ca.pem` to the example `DATABASE_URL` and mount that read-only CA file through a
+production overlay.
+
 ## Deploy and inspect the gateway
+
+Render and schema-check the base before applying it. CI runs the same validation with pinned kubectl and kubeconform
+releases against the Kubernetes 1.36 schema:
+
+```console
+kubectl kustomize deploy/kubernetes |
+  kubeconform -kubernetes-version 1.36.0 -strict -summary
+```
+
+This catches Kustomize build failures, unknown Kubernetes fields, duplicate keys, and schema type errors. It does not
+replace admission-policy or server-side validation in the target cluster, so validate environment overlays against a
+representative cluster before production rollout.
 
 Apply the base or the environment overlay:
 
@@ -127,6 +151,10 @@ development. Every `/v1/*` HTTP and WebSocket route then requires a valid bearer
 remain available to Kubernetes probes. Follow the [OIDC validation contract](../design/oidc-bearer-authentication.md)
 and the [GitHub and Dex tutorial](github-oidc.md) when configuring the provider and clients.
 
+Route only the authenticated `/v1/*` paths through a public Ingress; Kubernetes can probe `/health` and `/ready`
+directly through the pod network. If platform constraints expose either probe path, restrict or rate-limit it
+separately.
+
 Alternatively, put an identity-aware proxy or authenticated application service in front of the gateway. In that
 mode, leave the gateway's OIDC variables unset and ensure the trusted edge protects every `/v1/*` HTTP and WebSocket
 route. For ingress-nginx, configure external authentication and include settings equivalent to:
@@ -153,6 +181,10 @@ Its selectors
 admit only pods labeled `app.kubernetes.io/name=ingress-nginx` in the `ingress-nginx` namespace. Patch both selectors
 when the controller uses different labels or a different namespace. Keep the default-deny policy in place, and verify
 that the cluster's network plugin enforces NetworkPolicy before relying on it as a security boundary.
+
+Those selectors trust the whole matching ingress controller, not one Ingress object. In a shared or multi-tenant
+controller, use admission policy and RBAC to prevent untrusted routes from selecting this Service, or deploy a dedicated
+controller. Prefer mTLS or workload identity between the boundary and gateway when controller tenancy is not exclusive.
 
 The portable base does not restrict egress because the DNS resolver, managed PostgreSQL addresses, ports, and external
 inference destinations are environment-specific. Add a default-deny egress policy and explicit DNS, database, and

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -99,6 +99,7 @@ nav:
   - Deploying:
     - Container: deploying/container.md
     - GitHub authentication with Dex: deploying/github-oidc.md
+    - Kubernetes: deploying/kubernetes.md
   - Community: community/index.md
 
 extra:


### PR DESCRIPTION
## Summary

- add a Kustomize-compatible Kubernetes base with replicated gateway pods, probes, resource controls, disruption protection, and default-deny ingress
- make `/ready` check PostgreSQL and the inference service concurrently, fail fast on dependency failure, authenticate upstream health checks, reject redirects, coalesce overlapping probes, and log only readiness transitions
- validate rendered Kubernetes resources in CI with checksum-pinned `kubectl` and `kubeconform`
- document safe Secret creation, PostgreSQL TLS verification, image configuration, authenticated ingress boundaries, rollout behavior, and persistence verification
- advance #102 and close #108

## Test Plan

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `uvx pre-commit run --all-files`
- `uv run --with-requirements docs/requirements.txt mkdocs build`
- `kubectl kustomize deploy/kubernetes | kubeconform -strict -kubernetes-version 1.36.0` (7 valid resources)
- read-only Claude review and gstack pre-landing review, including independent adversarial review