### PR TITLE
Support Chat Completions protocol.

### DIFF
--- a/crates/agentic-server-core/src/config.rs
+++ b/crates/agentic-server-core/src/config.rs
@@ -1,3 +1,5 @@
+use crate::protocol::UpstreamApi;
+
 pub const DEFAULT_SQLITE_MAX_CONNECTIONS: u32 = 4;
 pub const DEFAULT_SQLITE_JOURNAL_SIZE_LIMIT_BYTES: u64 = 6_144_000;
 pub const DEFAULT_SQLITE_MMAP_SIZE_BYTES: u64 = 268_435_456;
@@ -43,6 +45,10 @@ impl Default for SqliteConfig {
 #[derive(Debug, Clone)]
 pub struct Config {
     pub llm_api_base: String,
+    /// Wire protocol spoken to the backend at `llm_api_base`. Defaults to the
+    /// Responses API; `ChatCompletions` targets backends that only serve
+    /// `/v1/chat/completions`.
+    pub upstream_api: UpstreamApi,
     pub openai_api_key: Option<String>,
     pub llm_ready_timeout_s: f64,
     pub llm_ready_interval_s: f64,

--- a/crates/agentic-server-core/src/executor/request.rs
+++ b/crates/agentic-server-core/src/executor/request.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use crate::config::Config;
 use crate::error::Error;
+use crate::protocol::UpstreamApi;
 use crate::executor::modes::{ConversationHandler, ResponseHandler};
 use crate::storage::{ConversationStore, ResponseStore, create_pool_with_schema_and_sqlite_config};
 use crate::tool::{GatewayExecutor, GatewayExecutors};
@@ -59,6 +60,9 @@ pub struct ExecutionContext {
     pub messages_gateway_tools: GatewayToolMap,
     /// Base URL for the LLM backend, e.g. `"http://localhost:8000"`.
     pub llm_base_url: String,
+    /// Wire protocol spoken to that backend. Selects the inference path and
+    /// whether request/response translation is applied.
+    pub upstream_api: UpstreamApi,
     /// Maximum wait time for the next SSE chunk.  `Duration::ZERO` disables the timeout.
     /// Sourced from [`Config::streaming_chunk_timeout_s`](crate::config::Config::streaming_chunk_timeout_s).
     pub streaming_timeout: Duration,
@@ -69,6 +73,15 @@ impl ExecutionContext {
     #[must_use]
     pub fn responses_url(&self) -> String {
         format!("{}/v1/responses", self.llm_base_url)
+    }
+
+    /// Returns the full URL for inference calls, honouring [`Self::upstream_api`].
+    ///
+    /// Prefer this over [`Self::responses_url`] for anything that goes through
+    /// the protocol adapters.
+    #[must_use]
+    pub fn inference_url(&self) -> String {
+        format!("{}{}", self.llm_base_url, self.upstream_api.inference_path())
     }
 
     /// Returns the full URL for the `/v1/conversations` endpoint.
@@ -92,6 +105,7 @@ impl ExecutionContext {
             gateway_executors,
             messages_gateway_tools: messages_gateway_tools_from_env(),
             llm_base_url,
+            upstream_api: UpstreamApi::default(),
             streaming_timeout: Duration::from_secs(30),
         }
     }
@@ -99,6 +113,13 @@ impl ExecutionContext {
     #[must_use]
     pub fn with_gateway_executor(mut self, executor: Arc<dyn GatewayExecutor>) -> Self {
         self.gateway_executors.insert(executor);
+        self
+    }
+
+    /// Override the upstream wire protocol.
+    #[must_use]
+    pub fn with_upstream_api(mut self, upstream_api: UpstreamApi) -> Self {
+        self.upstream_api = upstream_api;
         self
     }
 
@@ -129,6 +150,7 @@ impl ExecutionContext {
             gateway_executors,
             messages_gateway_tools: messages_gateway_tools_from_env(),
             llm_base_url: cfg.llm_api_base.clone(),
+            upstream_api: cfg.upstream_api,
             streaming_timeout: Duration::from_secs(30),
         })
     }

--- a/crates/agentic-server-core/src/executor/upstream.rs
+++ b/crates/agentic-server-core/src/executor/upstream.rs
@@ -10,6 +10,7 @@ use crate::executor::error::{ExecutorError, ExecutorResult};
 use crate::executor::gateway_accumulator::{GatewayStreamAccumulator, StreamEvent, emit_sse_frame};
 use crate::executor::inference::{call_inference, fetch_response_json};
 use crate::executor::request::{ExecutionContext, RequestContext};
+use crate::protocol::{UpstreamApi, chat};
 use crate::tool::ToolRegistry;
 use crate::types::request_response::ResponsePayload;
 use crate::utils::common::serialize_to_string;
@@ -32,12 +33,24 @@ pub(super) async fn fetch_blocking_payload(
     exec_ctx: &ExecutionContext,
     auth: Option<&str>,
 ) -> ExecutorResult<ResponsePayload> {
-    let url = exec_ctx.responses_url();
+    let url = exec_ctx.inference_url();
     // Non-streaming request: stream=false -> full JSON body -> from_json.
-    let upstream_request = ctx.enriched_request.to_upstream_request(false)?;
-    let upstream_json = serialize_to_string(&upstream_request).map_err(ExecutorError::JsonError)?;
+    let upstream_json = match exec_ctx.upstream_api {
+        UpstreamApi::Responses => {
+            let upstream_request = ctx.enriched_request.to_upstream_request(false)?;
+            serialize_to_string(&upstream_request).map_err(ExecutorError::JsonError)?
+        }
+        UpstreamApi::ChatCompletions => chat::request_json(&ctx.enriched_request, false)?,
+    };
 
     let body = fetch_response_json(upstream_json, &url, &exec_ctx.client, auth).await?;
+
+    // Translate back into the Responses shape so the accumulator — and
+    // everything downstream of it — stays protocol-agnostic.
+    let body = match exec_ctx.upstream_api {
+        UpstreamApi::Responses => body,
+        UpstreamApi::ChatCompletions => chat::response_to_responses_json(&body)?,
+    };
 
     let acc = ResponseAccumulator::from_json(&body, ctx.conversation_id.as_deref())?;
     let mut payload = acc.finalize(
@@ -61,6 +74,15 @@ pub(super) async fn fetch_stream_payload(
     )>,
     output_offset: usize,
 ) -> ExecutorResult<StreamPayload> {
+    // Chat Completions streams `chat.completion.chunk` deltas, which carry none
+    // of the response/item envelope the accumulator below consumes. Reject it
+    // outright rather than emitting a silently truncated stream.
+    if exec_ctx.upstream_api.is_chat_completions() {
+        return Err(ExecutorError::InvalidRequest(
+            "streaming is not supported when the upstream API is 'chat_completions'".to_owned(),
+        ));
+    }
+
     let url = exec_ctx.responses_url();
     let upstream_request = ctx.enriched_request.to_upstream_request(true)?;
     let upstream_json = serialize_to_string(&upstream_request).map_err(ExecutorError::JsonError)?;

--- a/crates/agentic-server-core/src/lib.rs
+++ b/crates/agentic-server-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod error;
 pub mod events;
 pub mod executor;
+pub mod protocol;
 pub mod proxy;
 pub mod readiness;
 pub mod storage;
@@ -9,6 +10,7 @@ pub mod tool;
 pub mod types;
 pub mod utils;
 
+pub use protocol::UpstreamApi;
 pub use storage::{
     ConversationData, ConversationStore, DbPool, InOutItem, ItemKind, ResponseData, ResponseMetadata, ResponseStore,
     SchemaManager, StorageError, StoreResult, create_pool, create_pool_with_schema,

--- a/crates/agentic-server-core/src/protocol/chat.rs
+++ b/crates/agentic-server-core/src/protocol/chat.rs
@@ -1,0 +1,527 @@
+//! Chat Completions upstream adapter.
+//!
+//! Translates the gateway's Responses-shaped requests into Chat Completions
+//! requests, and translates replies back into the Responses shape, so the rest
+//! of the executor keeps working exclusively in Responses terms.
+//!
+//! Streaming is deliberately unsupported: Chat Completions emits
+//! `chat.completion.chunk` deltas, which do not carry the response/item
+//! envelope the streaming accumulator expects. [`request_json`] rejects it
+//! rather than producing a silently malformed stream.
+
+use serde_json::{Map, Value, json};
+
+use crate::executor::error::{ExecutorError, ExecutorResult};
+use crate::types::event::MessageStatus;
+use crate::types::io::{
+    FunctionToolCall, InputContent, InputItem, InputMessageContent, OutputItem, OutputMessage, OutputTextContent,
+    ResponsesInput, ToolChoice,
+};
+use crate::types::request_response::{RequestPayload, UpstreamTool};
+use crate::utils::common::{deserialize_from_str, serialize_to_string, serialize_to_value, uuid7_str};
+
+/// Build a Chat Completions request body from a Responses request.
+///
+/// # Errors
+///
+/// Returns [`ExecutorError::InvalidRequest`] when `stream` is true, and
+/// propagates tool-normalization failures from
+/// [`RequestPayload::to_upstream_request`].
+pub fn request_json(request: &RequestPayload, stream: bool) -> ExecutorResult<String> {
+    if stream {
+        return Err(ExecutorError::InvalidRequest(
+            "streaming is not supported when the upstream API is 'chat_completions'".to_owned(),
+        ));
+    }
+
+    // Reuse the Responses normalization first: it flattens Codex namespaces,
+    // normalizes tool declarations, and folds compaction checkpoints into the
+    // input. Only the wire shape differs from here on.
+    let upstream = request.to_upstream_request(false)?;
+
+    let mut messages: Vec<Value> = Vec::new();
+    if let Some(instructions) = upstream.instructions {
+        messages.push(json!({ "role": "system", "content": instructions }));
+    }
+    match upstream.input.as_ref() {
+        ResponsesInput::Text(text) => messages.push(json!({ "role": "user", "content": text })),
+        ResponsesInput::Items(items) => {
+            for item in items {
+                push_message(&mut messages, item);
+            }
+        }
+    }
+
+    let mut body = Map::new();
+    body.insert("model".to_owned(), Value::String(upstream.model.to_owned()));
+    body.insert("messages".to_owned(), Value::Array(messages));
+    body.insert("stream".to_owned(), Value::Bool(false));
+
+    // Responses caps output with `max_output_tokens`; Chat Completions uses
+    // `max_tokens`.
+    if let Some(max_output_tokens) = upstream.max_output_tokens {
+        body.insert("max_tokens".to_owned(), json!(max_output_tokens));
+    }
+    if let Some(temperature) = upstream.temperature {
+        body.insert("temperature".to_owned(), json!(temperature));
+    }
+    if let Some(top_p) = upstream.top_p {
+        body.insert("top_p".to_owned(), json!(top_p));
+    }
+    if let Some(parallel_tool_calls) = upstream.parallel_tool_calls {
+        body.insert("parallel_tool_calls".to_owned(), json!(parallel_tool_calls));
+    }
+    // `tool_choice` is only valid alongside a non-empty `tools` array — Chat
+    // Completions rejects the request outright otherwise ("When using
+    // `tool_choice`, `tools` must be set"). `to_upstream_request` always
+    // resolves a choice, so the Responses path relies on
+    // `is_absent_or_default_tool_choice` to drop the default; mirror both rules
+    // here: emit only with tools, and never for the default `Auto`.
+    let tools = upstream
+        .tools
+        .as_deref()
+        .map(chat_tools)
+        .filter(|tools| !tools.is_empty());
+    if let Some(tools) = tools {
+        body.insert("tools".to_owned(), Value::Array(tools));
+        if let Some(tool_choice) = upstream
+            .tool_choice
+            .as_ref()
+            .filter(|choice| !matches!(choice, ToolChoice::Auto))
+            .and_then(chat_tool_choice)
+        {
+            body.insert("tool_choice".to_owned(), tool_choice);
+        }
+    }
+
+    serialize_to_string(&Value::Object(body)).map_err(ExecutorError::JsonError)
+}
+
+/// Translate a Chat Completions response body into the Responses shape consumed
+/// by [`crate::executor::accumulator::ResponseAccumulator::from_json`].
+///
+/// # Errors
+///
+/// Returns [`ExecutorError::JsonError`] if the body is not valid JSON, and
+/// [`ExecutorError::ParseError`] if it lacks `id` or `choices`.
+pub fn response_to_responses_json(body: &str) -> ExecutorResult<String> {
+    let chat: Value = deserialize_from_str(body).map_err(ExecutorError::JsonError)?;
+
+    let id = chat
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ExecutorError::ParseError("missing 'id' field in chat completion response".to_owned()))?
+        .to_owned();
+
+    let choice = chat
+        .get("choices")
+        .and_then(Value::as_array)
+        .and_then(|choices| choices.first())
+        .ok_or_else(|| ExecutorError::ParseError("chat completion response has no choices".to_owned()))?;
+
+    let message = choice.get("message").unwrap_or(&Value::Null);
+    let mut output: Vec<OutputItem> = Vec::new();
+
+    if let Some(text) = message
+        .get("content")
+        .and_then(Value::as_str)
+        .filter(|text| !text.is_empty())
+    {
+        let mut assistant = OutputMessage::new(uuid7_str("msg_"), MessageStatus::Completed);
+        assistant.content.push(OutputTextContent::new(text));
+        output.push(OutputItem::Message(assistant));
+    }
+
+    if let Some(tool_calls) = message.get("tool_calls").and_then(Value::as_array) {
+        for call in tool_calls {
+            let function = call.get("function").unwrap_or(&Value::Null);
+            output.push(OutputItem::FunctionCall(FunctionToolCall {
+                // The Responses item id is ours; `call_id` is the correlation
+                // key the client echoes back in `function_call_output`.
+                id: uuid7_str("fc_"),
+                call_id: string_at(call, "id"),
+                name: string_at(function, "name"),
+                namespace: None,
+                arguments: string_at(function, "arguments"),
+                status: MessageStatus::Completed,
+            }));
+        }
+    }
+
+    let truncated = choice.get("finish_reason").and_then(Value::as_str) == Some("length");
+
+    let mut response = Map::new();
+    response.insert("id".to_owned(), Value::String(id));
+    response.insert(
+        "output".to_owned(),
+        serialize_to_value(&output).map_err(ExecutorError::JsonError)?,
+    );
+    response.insert(
+        "status".to_owned(),
+        Value::String(if truncated { "incomplete" } else { "completed" }.to_owned()),
+    );
+    if truncated {
+        response.insert(
+            "incomplete_details".to_owned(),
+            json!({ "reason": "max_output_tokens" }),
+        );
+    }
+    if let Some(usage) = chat_usage(chat.get("usage").unwrap_or(&Value::Null)) {
+        response.insert("usage".to_owned(), usage);
+    }
+
+    serialize_to_string(&Value::Object(response)).map_err(ExecutorError::JsonError)
+}
+
+fn string_at(value: &Value, key: &str) -> String {
+    value.get(key).and_then(Value::as_str).unwrap_or_default().to_owned()
+}
+
+fn push_message(messages: &mut Vec<Value>, item: &InputItem) {
+    match item {
+        InputItem::Message(message) => messages.push(json!({
+            "role": message.role,
+            "content": message_text(&message.content),
+        })),
+        InputItem::FunctionCall(call) => messages.push(json!({
+            "role": "assistant",
+            "content": Value::Null,
+            "tool_calls": [{
+                "id": call.call_id,
+                "type": "function",
+                "function": { "name": call.name, "arguments": call.arguments },
+            }],
+        })),
+        InputItem::FunctionCallOutput(result) => messages.push(json!({
+            "role": "tool",
+            "tool_call_id": result.call_id,
+            "content": result.output,
+        })),
+        // Reasoning items, freeform custom tool traffic, and compaction
+        // checkpoints (already folded into messages by `model_input`) have no
+        // Chat Completions representation.
+        InputItem::CustomToolCall(_)
+        | InputItem::CustomToolCallOutput(_)
+        | InputItem::Reasoning(_)
+        | InputItem::Compaction(_)
+        | InputItem::Unknown => {}
+    }
+}
+
+fn message_text(content: &InputMessageContent) -> String {
+    match content {
+        InputMessageContent::Text(text) => text.clone(),
+        InputMessageContent::Parts(parts) => parts.iter().filter_map(part_text).collect::<Vec<_>>().join(""),
+    }
+}
+
+fn part_text(part: &InputContent) -> Option<&str> {
+    match part {
+        InputContent::InputText(text) | InputContent::OutputText(text) | InputContent::ReasoningText(text) => {
+            Some(text.text.as_str())
+        }
+        InputContent::InputImage(_) | InputContent::Unknown => None,
+    }
+}
+
+fn chat_tools(tools: &[UpstreamTool]) -> Vec<Value> {
+    tools
+        .iter()
+        .filter_map(|tool| match tool {
+            UpstreamTool::Function(function) => Some(json!({
+                "type": "function",
+                "function": {
+                    "name": function.name,
+                    "description": function.description,
+                    "parameters": function.parameters.clone().unwrap_or_else(|| json!({
+                        "type": "object",
+                        "properties": {},
+                    })),
+                },
+            })),
+            // Freeform custom tools are not expressible as Chat Completions
+            // functions; dropping them is better than sending an invalid shape.
+            UpstreamTool::Custom(_) => None,
+        })
+        .collect()
+}
+
+fn chat_tool_choice(choice: &ToolChoice) -> Option<Value> {
+    match choice {
+        ToolChoice::Auto => Some(Value::String("auto".to_owned())),
+        ToolChoice::None => Some(Value::String("none".to_owned())),
+        ToolChoice::Required => Some(Value::String("required".to_owned())),
+        ToolChoice::Function { name, .. } => Some(json!({
+            "type": "function",
+            "function": { "name": name.as_str() },
+        })),
+        // No Chat Completions equivalent — fall back to the default behaviour.
+        ToolChoice::Custom { .. } => None,
+    }
+}
+
+fn chat_usage(usage: &Value) -> Option<Value> {
+    if !usage.is_object() {
+        return None;
+    }
+    let input_tokens = usage.get("prompt_tokens").and_then(Value::as_i64).unwrap_or_default();
+    let output_tokens = usage
+        .get("completion_tokens")
+        .and_then(Value::as_i64)
+        .unwrap_or_default();
+    let total_tokens = usage
+        .get("total_tokens")
+        .and_then(Value::as_i64)
+        .unwrap_or(input_tokens + output_tokens);
+    Some(json!({
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(value: Value) -> RequestPayload {
+        serde_json::from_value(value).expect("valid request payload")
+    }
+
+    fn body(request: &RequestPayload) -> Value {
+        serde_json::from_str(&request_json(request, false).expect("request maps")).expect("valid json")
+    }
+
+    #[test]
+    fn text_input_becomes_user_message() {
+        let mapped = body(&request(json!({ "model": "m", "input": "hello" })));
+
+        assert_eq!(mapped["messages"], json!([{ "role": "user", "content": "hello" }]));
+        assert_eq!(mapped["model"], "m");
+        assert_eq!(mapped["stream"], false);
+    }
+
+    #[test]
+    fn instructions_become_leading_system_message() {
+        let mapped = body(&request(json!({
+            "model": "m",
+            "instructions": "be terse",
+            "input": "hello",
+        })));
+
+        assert_eq!(mapped["messages"][0], json!({ "role": "system", "content": "be terse" }));
+        assert_eq!(mapped["messages"][1]["role"], "user");
+    }
+
+    #[test]
+    fn max_output_tokens_becomes_max_tokens() {
+        let mapped = body(&request(json!({
+            "model": "m",
+            "input": "hello",
+            "max_output_tokens": 64,
+        })));
+
+        assert_eq!(mapped["max_tokens"], 64);
+        assert!(mapped.get("max_output_tokens").is_none());
+    }
+
+    #[test]
+    fn tool_call_history_becomes_assistant_and_tool_messages() {
+        let mapped = body(&request(json!({
+            "model": "m",
+            "input": [
+                { "type": "message", "role": "user", "content": "weather?" },
+                { "type": "function_call", "call_id": "call_1", "name": "get_weather", "arguments": "{}" },
+                { "type": "function_call_output", "call_id": "call_1", "output": "sunny" },
+            ],
+        })));
+
+        let messages = mapped["messages"].as_array().expect("messages array");
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[1]["role"], "assistant");
+        assert_eq!(messages[1]["tool_calls"][0]["id"], "call_1");
+        assert_eq!(messages[1]["tool_calls"][0]["function"]["name"], "get_weather");
+        assert_eq!(
+            messages[2],
+            json!({ "role": "tool", "tool_call_id": "call_1", "content": "sunny" })
+        );
+    }
+
+    #[test]
+    fn function_tools_are_nested_under_function_key() {
+        let mapped = body(&request(json!({
+            "model": "m",
+            "input": "hello",
+            "tools": [{
+                "type": "function",
+                "name": "get_weather",
+                "description": "look up weather",
+                "parameters": { "type": "object", "properties": {} },
+            }],
+        })));
+
+        assert_eq!(mapped["tools"][0]["type"], "function");
+        assert_eq!(mapped["tools"][0]["function"]["name"], "get_weather");
+        assert_eq!(mapped["tools"][0]["function"]["description"], "look up weather");
+    }
+
+    /// vLLM rejects `tool_choice` without `tools` ("When using `tool_choice`,
+    /// `tools` must be set"), and `to_upstream_request` always resolves a
+    /// choice — so a toolless request must not carry one.
+    #[test]
+    fn toolless_request_omits_tool_choice() {
+        let mapped = body(&request(json!({ "model": "m", "input": "hello" })));
+
+        assert!(mapped.get("tool_choice").is_none(), "got {mapped}");
+        assert!(mapped.get("tools").is_none(), "got {mapped}");
+    }
+
+    #[test]
+    fn default_auto_tool_choice_is_omitted_even_with_tools() {
+        let mapped = body(&request(json!({
+            "model": "m",
+            "input": "hello",
+            "tool_choice": "auto",
+            "tools": [{ "type": "function", "name": "f", "parameters": {} }],
+        })));
+
+        assert!(mapped.get("tools").is_some());
+        assert!(mapped.get("tool_choice").is_none(), "got {mapped}");
+    }
+
+    #[test]
+    fn explicit_tool_choice_is_forwarded_with_tools() {
+        let mapped = body(&request(json!({
+            "model": "m",
+            "input": "hello",
+            "tool_choice": "required",
+            "tools": [{ "type": "function", "name": "f", "parameters": {} }],
+        })));
+
+        assert_eq!(mapped["tool_choice"], "required");
+    }
+
+    #[test]
+    fn streaming_is_rejected() {
+        let error = request_json(&request(json!({ "model": "m", "input": "hi" })), true).unwrap_err();
+
+        assert!(error.to_string().contains("streaming is not supported"));
+    }
+
+    #[test]
+    fn response_content_becomes_output_message() {
+        let mapped: Value = serde_json::from_str(
+            &response_to_responses_json(
+                &json!({
+                    "id": "chatcmpl-1",
+                    "choices": [{
+                        "index": 0,
+                        "message": { "role": "assistant", "content": "hi there" },
+                        "finish_reason": "stop",
+                    }],
+                    "usage": { "prompt_tokens": 10, "completion_tokens": 6, "total_tokens": 16 },
+                })
+                .to_string(),
+            )
+            .expect("response maps"),
+        )
+        .expect("valid json");
+
+        assert_eq!(mapped["id"], "chatcmpl-1");
+        assert_eq!(mapped["status"], "completed");
+        assert_eq!(mapped["output"][0]["type"], "message");
+        assert_eq!(mapped["output"][0]["content"][0]["text"], "hi there");
+        assert_eq!(mapped["usage"], json!({
+            "input_tokens": 10,
+            "output_tokens": 6,
+            "total_tokens": 16,
+        }));
+    }
+
+    #[test]
+    fn length_finish_reason_marks_response_incomplete() {
+        let mapped: Value = serde_json::from_str(
+            &response_to_responses_json(
+                &json!({
+                    "id": "chatcmpl-1",
+                    "choices": [{ "message": { "content": "tru" }, "finish_reason": "length" }],
+                })
+                .to_string(),
+            )
+            .expect("response maps"),
+        )
+        .expect("valid json");
+
+        assert_eq!(mapped["status"], "incomplete");
+        assert_eq!(mapped["incomplete_details"]["reason"], "max_output_tokens");
+    }
+
+    #[test]
+    fn response_tool_calls_become_function_call_items() {
+        let mapped: Value = serde_json::from_str(
+            &response_to_responses_json(
+                &json!({
+                    "id": "chatcmpl-1",
+                    "choices": [{
+                        "message": {
+                            "content": Value::Null,
+                            "tool_calls": [{
+                                "id": "call_1",
+                                "type": "function",
+                                "function": { "name": "get_weather", "arguments": "{\"city\":\"NYC\"}" },
+                            }],
+                        },
+                        "finish_reason": "tool_calls",
+                    }],
+                })
+                .to_string(),
+            )
+            .expect("response maps"),
+        )
+        .expect("valid json");
+
+        assert_eq!(mapped["output"][0]["type"], "function_call");
+        assert_eq!(mapped["output"][0]["call_id"], "call_1");
+        assert_eq!(mapped["output"][0]["name"], "get_weather");
+    }
+
+    /// The accumulator drops output items it cannot deserialize, so a shape
+    /// mistake here would surface as a silently empty response rather than an
+    /// error. Round-trip through `OutputItem` to catch that.
+    #[test]
+    fn mapped_output_items_survive_deserialization() {
+        let mapped: Value = serde_json::from_str(
+            &response_to_responses_json(
+                &json!({
+                    "id": "chatcmpl-1",
+                    "choices": [{
+                        "message": {
+                            "content": "hi",
+                            "tool_calls": [{
+                                "id": "call_1",
+                                "function": { "name": "f", "arguments": "{}" },
+                            }],
+                        },
+                        "finish_reason": "stop",
+                    }],
+                })
+                .to_string(),
+            )
+            .expect("response maps"),
+        )
+        .expect("valid json");
+
+        let items: Vec<OutputItem> = serde_json::from_value(mapped["output"].clone()).expect("output items parse");
+
+        assert_eq!(items.len(), 2);
+        assert!(matches!(items[0], OutputItem::Message(_)));
+        assert!(matches!(items[1], OutputItem::FunctionCall(_)));
+    }
+
+    #[test]
+    fn missing_choices_is_a_parse_error() {
+        let error = response_to_responses_json(&json!({ "id": "chatcmpl-1" }).to_string()).unwrap_err();
+
+        assert!(error.to_string().contains("no choices"));
+    }
+}

--- a/crates/agentic-server-core/src/protocol/mod.rs
+++ b/crates/agentic-server-core/src/protocol/mod.rs
@@ -1,0 +1,97 @@
+//! Upstream inference protocol selection.
+//!
+//! The gateway's own client-facing API is always the Responses API. This module
+//! selects the wire protocol used to talk to the inference backend *behind* it:
+//! either the Responses API (vLLM's `/v1/responses`) or Chat Completions
+//! (`/v1/chat/completions`), for backends and proxies that serve only the
+//! latter.
+
+use std::fmt;
+use std::str::FromStr;
+
+pub mod chat;
+
+/// Wire protocol spoken to the upstream inference backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UpstreamApi {
+    /// `OpenAI` Responses API — the native protocol, requires no translation.
+    #[default]
+    Responses,
+    /// `OpenAI` Chat Completions API. Requests and replies are translated by
+    /// [`chat`]; streaming is not supported.
+    ChatCompletions,
+}
+
+impl UpstreamApi {
+    /// Path appended to the configured base URL for inference calls.
+    #[must_use]
+    pub fn inference_path(self) -> &'static str {
+        match self {
+            Self::Responses => "/v1/responses",
+            Self::ChatCompletions => "/v1/chat/completions",
+        }
+    }
+
+    #[must_use]
+    pub fn is_chat_completions(self) -> bool {
+        matches!(self, Self::ChatCompletions)
+    }
+}
+
+impl fmt::Display for UpstreamApi {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::Responses => "responses",
+            Self::ChatCompletions => "chat_completions",
+        };
+        f.write_str(name)
+    }
+}
+
+impl FromStr for UpstreamApi {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().replace('-', "_").as_str() {
+            "responses" => Ok(Self::Responses),
+            "chat_completions" | "chat" => Ok(Self::ChatCompletions),
+            other => Err(format!(
+                "unknown upstream API '{other}' (expected 'responses' or 'chat_completions')"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_known_names() {
+        assert_eq!("responses".parse::<UpstreamApi>().unwrap(), UpstreamApi::Responses);
+        assert_eq!(
+            "chat_completions".parse::<UpstreamApi>().unwrap(),
+            UpstreamApi::ChatCompletions
+        );
+        assert_eq!(
+            "Chat-Completions".parse::<UpstreamApi>().unwrap(),
+            UpstreamApi::ChatCompletions
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_names() {
+        assert!("completions".parse::<UpstreamApi>().is_err());
+    }
+
+    #[test]
+    fn paths_match_protocol() {
+        assert_eq!(UpstreamApi::Responses.inference_path(), "/v1/responses");
+        assert_eq!(UpstreamApi::ChatCompletions.inference_path(), "/v1/chat/completions");
+    }
+
+    #[test]
+    fn default_is_responses() {
+        assert_eq!(UpstreamApi::default(), UpstreamApi::Responses);
+    }
+}

--- a/crates/agentic-server-core/src/proxy.rs
+++ b/crates/agentic-server-core/src/proxy.rs
@@ -312,6 +312,7 @@ mod tests {
     fn test_config() -> Config {
         Config {
             llm_api_base: "http://localhost:8000".to_owned(),
+            upstream_api: crate::protocol::UpstreamApi::default(),
             openai_api_key: Some("test-key".to_owned()),
             llm_ready_timeout_s: 5.0,
             llm_ready_interval_s: 0.1,

--- a/crates/agentic-server/benches/gateway_bench.rs
+++ b/crates/agentic-server/benches/gateway_bench.rs
@@ -154,6 +154,7 @@ async fn spawn_gateway(llm_url: &str) -> (Arc<reqwest::Client>, String) {
 
     let config = Config {
         llm_api_base: llm_url.to_owned(),
+        upstream_api: agentic_core::protocol::UpstreamApi::default(),
         openai_api_key: None,
         llm_ready_timeout_s: 5.0,
         llm_ready_interval_s: 0.1,

--- a/crates/agentic-server/benches/proxy_bench.rs
+++ b/crates/agentic-server/benches/proxy_bench.rs
@@ -26,6 +26,7 @@ const PROMPT_SIZES: [usize; 3] = [1024, 10 * 1024, 100 * 1024];
 fn bench_config(llm_url: &str) -> Config {
     Config {
         llm_api_base: llm_url.to_owned(),
+        upstream_api: agentic_core::protocol::UpstreamApi::default(),
         openai_api_key: Some("bench-key".to_owned()),
         llm_ready_timeout_s: 5.0,
         llm_ready_interval_s: 0.1,

--- a/crates/agentic-server/src/handler/http/responses.rs
+++ b/crates/agentic-server/src/handler/http/responses.rs
@@ -53,7 +53,11 @@ pub async fn responses(State(state): State<AppState>, req: Request) -> Response 
         Err(e) => return e,
     };
 
-    let should_execute = payload.store
+    // The proxy path forwards the Responses body verbatim, which a Chat
+    // Completions backend rejects. Under that upstream every request must go
+    // through the executor so the protocol adapter runs.
+    let should_execute = state.exec_ctx.upstream_api.is_chat_completions()
+        || payload.store
         || payload.previous_response_id.is_some()
         || payload.conversation_id.is_some()
         || payload.input.contains_compaction()

--- a/crates/agentic-server/src/main.rs
+++ b/crates/agentic-server/src/main.rs
@@ -5,6 +5,7 @@ use agentic_core::config::{
     SqliteConfig, SqliteTempStore, normalize_base_url,
 };
 use agentic_core::error::Error;
+use agentic_core::protocol::UpstreamApi;
 
 mod server;
 
@@ -28,6 +29,12 @@ struct CommonArgs {
     /// Skip the upstream /health readiness probe. Useful for hosted OpenAI-compatible providers.
     #[arg(long, env = "SKIP_LLM_READY_CHECK", default_value_t = false, global = true)]
     skip_llm_ready_check: bool,
+
+    /// Wire protocol spoken to the upstream backend: `responses` (default) or
+    /// `chat_completions` for backends that only serve `/v1/chat/completions`.
+    /// Streaming requires `responses`.
+    #[arg(long, env = "UPSTREAM_API", default_value = "responses", global = true)]
+    upstream_api: UpstreamApi,
 
     /// `SQLite` or `PostgreSQL` URL for conversation and response storage.
     /// Defaults to a local `SQLite` file.
@@ -138,6 +145,7 @@ fn sqlite_config_from_env() -> Result<SqliteConfig, Error> {
 fn build_config(llm_api_base: String, common: &CommonArgs) -> Result<Config, Error> {
     Ok(Config {
         llm_api_base,
+        upstream_api: common.upstream_api,
         openai_api_key: common.openai_api_key.clone(),
         llm_ready_timeout_s: common.llm_ready_timeout_s,
         llm_ready_interval_s: common.llm_ready_interval_s,

--- a/crates/agentic-server/tests/common/mod.rs
+++ b/crates/agentic-server/tests/common/mod.rs
@@ -16,6 +16,7 @@ use agentic_server::app::{AppState, ServerConfig, WebSocketTracker, build_router
 pub fn test_config(llm_url: &str) -> Config {
     Config {
         llm_api_base: llm_url.to_owned(),
+        upstream_api: agentic_core::protocol::UpstreamApi::default(),
         openai_api_key: Some("test-key".to_owned()),
         llm_ready_timeout_s: 5.0,
         llm_ready_interval_s: 0.1,


### PR DESCRIPTION
## Summary

The gateway always calls the backend `/v1/responses`. Some OpenAI-compatible backends and proxies serve only `/v1/chat/completions`, which makes them unusable as an upstream today.

This adds `--upstream-api` / `UPSTREAM_API` with two values: `responses` (default, unchanged behaviour) and `chat_completions`.

A new `protocol` module holds the switch and the translation. Requests are reshaped from the Responses form (`input` -> `messages`, `instructions` -> a leading system message, ...). Replies are translated back into Responses-shaped
JSON and handed to the existing accumulator, so storage, the tool loop, and compaction stay protocol-agnostic.

Note: Streaming is unsupported in this mode and returns an explicit error. Chat Completions emits `chat.completion.chunk` deltas, which carry none of the response/item envelope the streaming accumulator consumes; failing loudly seemed better than emitting a malformed stream. Follow-up work.


Note for reviewers: `Config` and `ExecutionContext` each gain a public field, so external code constructing them literally will need updating. Happy to add `#[non_exhaustive]` + `Default` instead if you'd prefer to avoid that.

Relates to #165.

## Test Plan

- 18 unit tests in `protocol::` covering both mappers: field renames, instructions -> system message, tool-call history round-trip, tool declarations, `finish_reason: "length"` -> `status: "incomplete"`, usage mapping, and rejection of streaming.
- Manual end-to-end against a live vLLM backend with `UPSTREAM_API=chat_completions`: single-turn generation, and a two-turn conversation chained by `previous_response_id` that correctly recalled state from the first turn.
- Default (`responses`) path re-verified unchanged on the same build.

