### PR TITLE
fix: harden custom tool SSE edge cases

### DIFF
--- a/crates/agentic-server-core/src/executor/accumulator.rs
+++ b/crates/agentic-server-core/src/executor/accumulator.rs
@@ -286,7 +286,7 @@ impl ResponseAccumulator {
         let entry = self
             .in_flight
             .get(item_id)
-            .filter(|entry| matches!(entry.item, InFlight::FunctionCall { .. }))
+            .filter(|entry| entry.output_index == output_index && matches!(entry.item, InFlight::FunctionCall { .. }))
             .or_else(|| {
                 self.in_flight.values().find(|entry| {
                     entry.output_index == output_index && matches!(entry.item, InFlight::FunctionCall { .. })
@@ -374,16 +374,35 @@ impl ResponseAccumulator {
                     item.apply_done(&frame.payload, text);
                 }
             }
-            (SSEEventType::FunctionCallArgumentsDelta, EventPayload::FunctionCallArgsDelta { delta, item_id, .. }) => {
-                if let Some(InFlight::FunctionCall { arguments, .. }) =
-                    self.in_flight.get_mut(item_id).map(|entry| &mut entry.item)
+            (
+                SSEEventType::FunctionCallArgumentsDelta,
+                EventPayload::FunctionCallArgsDelta {
+                    delta,
+                    item_id,
+                    output_index,
+                    ..
+                },
+            ) => {
+                let key = self.in_flight_call_key(item_id, SSEItemType::FunctionCall, *output_index);
+                if let Some(InFlight::FunctionCall { arguments, .. }) = key
+                    .as_deref()
+                    .and_then(|key| self.in_flight.get_mut(key))
+                    .map(|entry| &mut entry.item)
                 {
                     arguments.push_str(delta);
                 }
             }
-            (SSEEventType::FunctionCallArgumentsDone, EventPayload::FunctionCallArgsDone { item_id, .. }) => {
-                if let Some(InFlight::FunctionCall { item, arguments }) =
-                    self.in_flight.get_mut(item_id).map(|entry| &mut entry.item)
+            (
+                SSEEventType::FunctionCallArgumentsDone,
+                EventPayload::FunctionCallArgsDone {
+                    item_id, output_index, ..
+                },
+            ) => {
+                let key = self.in_flight_call_key(item_id, SSEItemType::FunctionCall, *output_index);
+                if let Some(InFlight::FunctionCall { item, arguments }) = key
+                    .as_deref()
+                    .and_then(|key| self.in_flight.get_mut(key))
+                    .map(|entry| &mut entry.item)
                 {
                     item.apply_done(&frame.payload, arguments);
                 }
@@ -460,8 +479,19 @@ impl ResponseAccumulator {
             SSEItemType::McpCall => McpCall::try_from(payload).ok().map(|item| InFlight::McpCall { item }),
         };
         if let Some(item) = item {
+            let needs_internal_key = matches!(&item, InFlight::FunctionCall { .. })
+                && (item_id.is_empty() || self.in_flight.contains_key(item_id));
+            let key = if needs_internal_key {
+                let mut key = format!("__output_index_{output_index}");
+                while self.in_flight.contains_key(&key) {
+                    key.push('_');
+                }
+                key
+            } else {
+                item_id.clone()
+            };
             self.in_flight.insert(
-                item_id.clone(),
+                key,
                 InFlightEntry {
                     output_index: *output_index,
                     item,
@@ -529,7 +559,7 @@ impl ResponseAccumulator {
     fn in_flight_call_key(&self, item_id: &str, item_type: SSEItemType, output_index: u32) -> Option<String> {
         self.in_flight
             .get(item_id)
-            .filter(|entry| in_flight_matches_call_type(&entry.item, item_type))
+            .filter(|entry| entry.output_index == output_index && in_flight_matches_call_type(&entry.item, item_type))
             .map(|_| item_id.to_owned())
             .or_else(|| {
                 self.in_flight.iter().find_map(|(key, entry)| {

--- a/crates/agentic-server-core/src/executor/function_sse.rs
+++ b/crates/agentic-server-core/src/executor/function_sse.rs
@@ -13,19 +13,9 @@ const MAX_PENDING_FUNCTION_BYTES: usize = 256 * 1024;
 
 #[derive(Debug)]
 enum FunctionCallShape {
-    PublicFunction { output_index: u32 },
-    GatewayOwned { output_index: u32 },
+    PublicFunction,
+    GatewayOwned,
     Custom(CustomCallState),
-}
-
-impl FunctionCallShape {
-    const fn output_index(&self) -> u32 {
-        match self {
-            Self::PublicFunction { output_index }
-            | Self::GatewayOwned { output_index }
-            | Self::Custom(CustomCallState { output_index, .. }) => *output_index,
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -33,6 +23,8 @@ struct CustomCallState {
     public_item_id: String,
     output_index: u32,
     emitted_input: String,
+    input_start: Option<usize>,
+    input_cursor: usize,
     input_done: bool,
 }
 
@@ -55,8 +47,8 @@ pub(super) struct FunctionSseTranslation {
 #[derive(Debug, Default)]
 pub(super) struct FunctionSseTranslator {
     tool_types: HashMap<String, ToolType>,
-    active: HashMap<String, FunctionCallShape>,
-    pending_unnamed: HashMap<String, PendingFunctionCall>,
+    active: HashMap<u32, FunctionCallShape>,
+    pending_unnamed: HashMap<u32, PendingFunctionCall>,
     pending_bytes: usize,
     first_gateway_output_index: Option<u32>,
 }
@@ -83,12 +75,12 @@ impl FunctionSseTranslator {
                 ..
             } => self.start_call(item_id, name, *output_index, Some(frame.clone()), call),
             EventPayload::OutputItemAdded {
-                item_id,
+                item_id: _,
                 item_type: SSEItemType::FunctionCall,
                 output_index,
                 name: None,
                 ..
-            } => self.buffer_unnamed(item_id.clone(), *output_index, frame),
+            } => self.buffer_unnamed(*output_index, frame),
             EventPayload::FunctionCallArgsDelta {
                 item_id, output_index, ..
             } => self.translate_delta(item_id, *output_index, frame.clone(), call),
@@ -126,12 +118,18 @@ impl FunctionSseTranslator {
     ) -> ExecutorResult<FunctionSseTranslation> {
         match self.tool_type(name) {
             ToolType::Custom => {
+                let public_item_id = call.as_ref().map_or_else(
+                    || crate::tool::custom::public_item_id(item_id),
+                    |call| crate::tool::custom::public_item_id(&call.item.id),
+                );
                 self.active.insert(
-                    item_id.to_owned(),
+                    output_index,
                     FunctionCallShape::Custom(CustomCallState {
-                        public_item_id: crate::tool::custom::public_item_id(item_id),
+                        public_item_id,
                         output_index,
                         emitted_input: String::new(),
+                        input_start: None,
+                        input_cursor: 0,
                         input_done: false,
                     }),
                 );
@@ -148,13 +146,11 @@ impl FunctionSseTranslator {
                 if self.first_gateway_output_index.is_none_or(|first| output_index < first) {
                     self.first_gateway_output_index = Some(output_index);
                 }
-                self.active
-                    .insert(item_id.to_owned(), FunctionCallShape::GatewayOwned { output_index });
+                self.active.insert(output_index, FunctionCallShape::GatewayOwned);
                 Ok(FunctionSseTranslation::default())
             }
             ToolType::Function | ToolType::CodexNamespace => {
-                self.active
-                    .insert(item_id.to_owned(), FunctionCallShape::PublicFunction { output_index });
+                self.active.insert(output_index, FunctionCallShape::PublicFunction);
                 Ok(FunctionSseTranslation {
                     frames: original.into_iter().collect(),
                     defer_from_output_index: None,
@@ -165,18 +161,17 @@ impl FunctionSseTranslator {
 
     fn translate_delta(
         &mut self,
-        item_id: &str,
+        _item_id: &str,
         output_index: u32,
         original: EventFrame,
         call: Option<AccumulatedFunctionCall<'_>>,
     ) -> ExecutorResult<FunctionSseTranslation> {
-        let key = self.active_key(item_id, output_index);
-        match key.as_deref().and_then(|key| self.active.get_mut(key)) {
-            Some(FunctionCallShape::PublicFunction { .. }) => Ok(FunctionSseTranslation {
+        match self.active.get_mut(&output_index) {
+            Some(FunctionCallShape::PublicFunction) => Ok(FunctionSseTranslation {
                 frames: vec![original],
                 defer_from_output_index: None,
             }),
-            Some(FunctionCallShape::GatewayOwned { .. }) => Ok(FunctionSseTranslation::default()),
+            Some(FunctionCallShape::GatewayOwned) => Ok(FunctionSseTranslation::default()),
             Some(FunctionCallShape::Custom(state)) => {
                 let frame = match call {
                     Some(call) => incremental_custom_delta(state, call.arguments())?,
@@ -187,7 +182,7 @@ impl FunctionSseTranslator {
                     defer_from_output_index: None,
                 })
             }
-            None => self.buffer_unnamed(item_id.to_owned(), output_index, original),
+            None => self.buffer_unnamed(output_index, original),
         }
     }
 
@@ -200,10 +195,9 @@ impl FunctionSseTranslator {
         call: Option<AccumulatedFunctionCall<'_>>,
     ) -> ExecutorResult<FunctionSseTranslation> {
         let mut translated = self.resolve_pending(item_id, name, output_index, call)?;
-        let key = self.active_key(item_id, output_index);
-        match key.as_deref().and_then(|key| self.active.get_mut(key)) {
-            Some(FunctionCallShape::PublicFunction { .. }) | None => translated.frames.push(original),
-            Some(FunctionCallShape::GatewayOwned { .. }) => {}
+        match self.active.get_mut(&output_index) {
+            Some(FunctionCallShape::PublicFunction) | None => translated.frames.push(original),
+            Some(FunctionCallShape::GatewayOwned) => {}
             Some(FunctionCallShape::Custom(state)) => {
                 if let Some(call) = call {
                     translated.frames.extend(finish_custom_input(state, call.arguments())?);
@@ -222,10 +216,9 @@ impl FunctionSseTranslator {
         call: Option<AccumulatedFunctionCall<'_>>,
     ) -> ExecutorResult<FunctionSseTranslation> {
         let mut translated = self.resolve_pending(item_id, name, output_index, call)?;
-        let key = self.active_key(item_id, output_index);
-        match key.as_deref().and_then(|key| self.active.remove(key)) {
-            Some(FunctionCallShape::PublicFunction { .. }) | None => translated.frames.push(original),
-            Some(FunctionCallShape::GatewayOwned { .. }) => {}
+        match self.active.remove(&output_index) {
+            Some(FunctionCallShape::PublicFunction) | None => translated.frames.push(original),
+            Some(FunctionCallShape::GatewayOwned) => {}
             Some(FunctionCallShape::Custom(mut state)) => {
                 if let Some(call) = call {
                     translated
@@ -245,11 +238,11 @@ impl FunctionSseTranslator {
         output_index: u32,
         call: Option<AccumulatedFunctionCall<'_>>,
     ) -> ExecutorResult<FunctionSseTranslation> {
-        if self.active_key(item_id, output_index).is_some() {
+        if self.active.contains_key(&output_index) {
             return Ok(FunctionSseTranslation::default());
         }
 
-        let pending = self.take_pending(item_id, output_index);
+        let pending = self.take_pending(output_index);
         let original_added = pending.iter().find(|frame| {
             matches!(
                 frame.payload,
@@ -281,23 +274,7 @@ impl FunctionSseTranslator {
             .min()
     }
 
-    fn active_key(&self, item_id: &str, output_index: u32) -> Option<String> {
-        self.active
-            .contains_key(item_id)
-            .then(|| item_id.to_owned())
-            .or_else(|| {
-                self.active
-                    .iter()
-                    .find_map(|(key, shape)| (shape.output_index() == output_index).then(|| key.clone()))
-            })
-    }
-
-    fn buffer_unnamed(
-        &mut self,
-        item_id: String,
-        output_index: u32,
-        frame: EventFrame,
-    ) -> ExecutorResult<FunctionSseTranslation> {
+    fn buffer_unnamed(&mut self, output_index: u32, frame: EventFrame) -> ExecutorResult<FunctionSseTranslation> {
         let bytes = serialize_to_string(&frame.wire)
             .map_err(ExecutorError::JsonError)?
             .len();
@@ -308,7 +285,7 @@ impl FunctionSseTranslator {
         }
         let pending = self
             .pending_unnamed
-            .entry(item_id)
+            .entry(output_index)
             .or_insert_with(|| PendingFunctionCall {
                 output_index,
                 ..PendingFunctionCall::default()
@@ -319,17 +296,8 @@ impl FunctionSseTranslator {
         Ok(FunctionSseTranslation::default())
     }
 
-    fn take_pending(&mut self, item_id: &str, output_index: u32) -> Vec<EventFrame> {
-        let key = self
-            .pending_unnamed
-            .contains_key(item_id)
-            .then(|| item_id.to_owned())
-            .or_else(|| {
-                self.pending_unnamed
-                    .iter()
-                    .find_map(|(key, pending)| (pending.output_index == output_index).then(|| key.clone()))
-            });
-        let Some(pending) = key.and_then(|key| self.pending_unnamed.remove(&key)) else {
+    fn take_pending(&mut self, output_index: u32) -> Vec<EventFrame> {
+        let Some(pending) = self.pending_unnamed.remove(&output_index) else {
             return Vec::new();
         };
         self.pending_bytes = self.pending_bytes.saturating_sub(pending.bytes);
@@ -356,17 +324,11 @@ fn custom_added_frame(call: &AccumulatedFunctionCall<'_>) -> ExecutorResult<Even
 }
 
 fn incremental_custom_delta(state: &mut CustomCallState, arguments: &str) -> ExecutorResult<Option<EventFrame>> {
-    let Some(input) = partial_custom_input(arguments) else {
+    ensure_function_call_size(arguments)?;
+    let Some(delta) = partial_custom_input(state, arguments)? else {
         return Ok(None);
     };
-    let Some(delta) = input
-        .strip_prefix(&state.emitted_input)
-        .filter(|delta| !delta.is_empty())
-        .map(str::to_owned)
-    else {
-        return Ok(None);
-    };
-    state.emitted_input = input;
+    state.emitted_input.push_str(&delta);
     custom_frame(
         SSEEventType::CustomToolCallInputDelta,
         state.output_index,
@@ -382,11 +344,14 @@ fn finish_custom_input(state: &mut CustomCallState, arguments: &str) -> Executor
     if state.input_done {
         return Ok(Vec::new());
     }
+    ensure_function_call_size(arguments)?;
     let input = crate::tool::custom::input_from_arguments(arguments);
-    let remaining = input
-        .strip_prefix(&state.emitted_input)
-        .filter(|delta| !delta.is_empty())
-        .map(str::to_owned);
+    let Some(remaining) = input.strip_prefix(&state.emitted_input) else {
+        return Err(ExecutorError::StreamError(
+            "authoritative custom tool input contradicts streamed custom tool input".to_owned(),
+        ));
+    };
+    let remaining = (!remaining.is_empty()).then(|| remaining.to_owned());
     state.emitted_input.clone_from(&input);
     state.input_done = true;
 
@@ -440,7 +405,96 @@ fn custom_frame(
     Ok(frame)
 }
 
-fn partial_custom_input(arguments: &str) -> Option<String> {
+fn ensure_function_call_size(arguments: &str) -> ExecutorResult<()> {
+    if arguments.len() > MAX_PENDING_FUNCTION_BYTES {
+        return Err(ExecutorError::StreamError(format!(
+            "function-call SSE exceeded {MAX_PENDING_FUNCTION_BYTES} buffered bytes"
+        )));
+    }
+    Ok(())
+}
+
+fn partial_custom_input(state: &mut CustomCallState, arguments: &str) -> ExecutorResult<Option<String>> {
+    let input_start = if let Some(input_start) = state.input_start {
+        input_start
+    } else {
+        let Some(input_start) = custom_input_start(arguments) else {
+            return Ok(None);
+        };
+        state.input_start = Some(input_start);
+        state.input_cursor = input_start;
+        input_start
+    };
+    if state.input_cursor < input_start || state.input_cursor > arguments.len() {
+        return Ok(None);
+    }
+    let encoded = &arguments[state.input_cursor..];
+    let end = complete_json_string_prefix(encoded);
+    if end == 0 {
+        return Ok(None);
+    }
+    let candidate = format!("\"{}\"", &encoded[..end]);
+    let delta = serde_json::from_str::<String>(&candidate)
+        .map_err(|error| ExecutorError::StreamError(format!("invalid custom tool input string: {error}")))?;
+    state.input_cursor = state.input_cursor.saturating_add(end);
+    Ok((!delta.is_empty()).then_some(delta))
+}
+
+fn complete_json_string_prefix(value: &str) -> usize {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'"' => return index,
+            b'\\' => {
+                let Some(escape) = bytes.get(index + 1) else {
+                    return index;
+                };
+                if *escape == b'u' {
+                    let unicode_end = index.saturating_add(6);
+                    if unicode_end > bytes.len() {
+                        return index;
+                    }
+                    let Some(code_unit) = json_hex_quad(&bytes[index + 2..unicode_end]) else {
+                        index = unicode_end;
+                        continue;
+                    };
+                    if (0xD800..=0xDBFF).contains(&code_unit) {
+                        let pair_end = index.saturating_add(12);
+                        if pair_end > bytes.len() {
+                            return index;
+                        }
+                        index = pair_end;
+                    } else {
+                        index = unicode_end;
+                    }
+                } else {
+                    index = index.saturating_add(2);
+                }
+            }
+            _ => index = index.saturating_add(1),
+        }
+    }
+    index
+}
+
+fn json_hex_quad(bytes: &[u8]) -> Option<u16> {
+    if bytes.len() != 4 {
+        return None;
+    }
+    bytes.iter().try_fold(0_u16, |value, byte| {
+        let digit = byte.to_ascii_lowercase();
+        let digit = match digit {
+            b'0'..=b'9' => u16::from(digit - b'0'),
+            b'a'..=b'f' => u16::from(digit - b'a' + 10),
+            _ => return None,
+        };
+        value.checked_mul(16)?.checked_add(digit)
+    })
+}
+
+fn custom_input_start(arguments: &str) -> Option<usize> {
+    let original_len = arguments.len();
     let arguments = arguments.trim_start();
     let arguments = arguments.strip_prefix("{}").unwrap_or(arguments).trim_start();
     let encoded = arguments
@@ -451,31 +505,7 @@ fn partial_custom_input(arguments: &str) -> Option<String> {
         .strip_prefix(':')?
         .trim_start()
         .strip_prefix('"')?;
-    let end = unescaped_quote(encoded).unwrap_or(encoded.len());
-    let mut end = end;
-    loop {
-        let candidate = format!("\"{}\"", &encoded[..end]);
-        if let Ok(input) = serde_json::from_str::<String>(&candidate) {
-            return Some(input);
-        }
-        end = encoded[..end].rfind('\\')?;
-    }
-}
-
-fn unescaped_quote(value: &str) -> Option<usize> {
-    let mut escaped = false;
-    value.char_indices().find_map(|(index, character)| {
-        if escaped {
-            escaped = false;
-            return None;
-        }
-        match character {
-            '\\' => escaped = true,
-            '"' => return Some(index),
-            _ => {}
-        }
-        None
-    })
+    Some(original_len.saturating_sub(encoded.len()))
 }
 
 #[cfg(test)]
@@ -580,6 +610,156 @@ mod tests {
     }
 
     #[test]
+    fn custom_input_deltas_match_authoritative_done_input() {
+        let mut accumulator = ResponseAccumulator::new("resp_1".to_owned(), None);
+        let mut translator = FunctionSseTranslator::new(HashMap::from([("raw_echo".to_owned(), ToolType::Custom)]));
+        let events = [
+            serde_json::json!({
+                "type": "response.output_item.added", "output_index": 0,
+                "item": {"id": "fc_1", "type": "function_call", "call_id": "call_1",
+                    "name": "raw_echo", "arguments": "", "status": "in_progress"}
+            }),
+            serde_json::json!({
+                "type": "response.function_call_arguments.delta", "output_index": 0,
+                "item_id": "fc_1", "call_id": "call_1", "delta": "{\"input\":\"hello\""
+            }),
+            serde_json::json!({
+                "type": "response.function_call_arguments.done", "output_index": 0,
+                "item_id": "fc_1", "call_id": "call_1", "name": "raw_echo",
+                "arguments": "{\"input\":\"hello\",\"extra\":true}"
+            }),
+            serde_json::json!({
+                "type": "response.output_item.done", "output_index": 0,
+                "item": {"id": "fc_1", "type": "function_call", "call_id": "call_1",
+                    "name": "raw_echo", "arguments": "{\"input\":\"hello\",\"extra\":true}", "status": "completed"}
+            }),
+        ];
+
+        let mut frames = Vec::new();
+        for event in events {
+            frames.extend(translate(&mut accumulator, &mut translator, &event).frames);
+        }
+        let deltas = frames
+            .iter()
+            .filter(|frame| frame.event_type == SSEEventType::CustomToolCallInputDelta)
+            .filter_map(|frame| frame.wire.rest["delta"].as_str())
+            .collect::<String>();
+        let done = frames
+            .iter()
+            .find(|frame| frame.event_type == SSEEventType::CustomToolCallInputDone)
+            .and_then(|frame| frame.wire.rest["input"].as_str())
+            .expect("input.done");
+
+        assert_eq!(deltas, done);
+    }
+
+    #[test]
+    fn custom_input_rejects_authoritative_value_that_contradicts_deltas() {
+        let mut accumulator = ResponseAccumulator::new("resp_1".to_owned(), None);
+        let mut translator = FunctionSseTranslator::new(HashMap::from([("raw_echo".to_owned(), ToolType::Custom)]));
+        let events = [
+            serde_json::json!({
+                "type": "response.output_item.added", "output_index": 0,
+                "item": {"id": "fc_1", "type": "function_call", "call_id": "call_1",
+                    "name": "raw_echo", "arguments": "", "status": "in_progress"}
+            }),
+            serde_json::json!({
+                "type": "response.function_call_arguments.delta", "output_index": 0,
+                "item_id": "fc_1", "call_id": "call_1", "delta": "{\"input\":\"hello\"}"
+            }),
+        ];
+        for event in events {
+            translate(&mut accumulator, &mut translator, &event);
+        }
+        let done = serde_json::json!({
+            "type": "response.function_call_arguments.done", "output_index": 0,
+            "item_id": "fc_1", "call_id": "call_1", "name": "raw_echo",
+            "arguments": "{\"input\":\"bye\"}"
+        });
+
+        let error = accumulator
+            .process_sse_line_with_translator(&sse(&done), &mut translator)
+            .expect_err("contradictory final input must fail");
+        assert!(error.to_string().contains("contradicts streamed custom tool input"));
+    }
+
+    #[test]
+    fn malformed_custom_input_escape_is_rejected() {
+        let mut accumulator = ResponseAccumulator::new("resp_1".to_owned(), None);
+        let mut translator = FunctionSseTranslator::new(HashMap::from([("raw_echo".to_owned(), ToolType::Custom)]));
+        let added = serde_json::json!({
+            "type": "response.output_item.added", "output_index": 0,
+            "item": {"id": "fc_1", "type": "function_call", "call_id": "call_1",
+                "name": "raw_echo", "arguments": "", "status": "in_progress"}
+        });
+        translate(&mut accumulator, &mut translator, &added);
+        let delta = serde_json::json!({
+            "type": "response.function_call_arguments.delta", "output_index": 0,
+            "item_id": "fc_1", "call_id": "call_1", "delta": r#"{"input":"\q"#
+        });
+
+        let error = accumulator
+            .process_sse_line_with_translator(&sse(&delta), &mut translator)
+            .expect_err("invalid JSON string escape must fail");
+        assert!(error.to_string().contains("invalid custom tool input"));
+    }
+
+    #[test]
+    fn custom_input_waits_for_split_unicode_surrogate_pair() {
+        let mut accumulator = ResponseAccumulator::new("resp_1".to_owned(), None);
+        let mut translator = FunctionSseTranslator::new(HashMap::from([("raw_echo".to_owned(), ToolType::Custom)]));
+        let events = [
+            serde_json::json!({
+                "type": "response.output_item.added", "output_index": 0,
+                "item": {"id": "fc_1", "type": "function_call", "call_id": "call_1",
+                    "name": "raw_echo", "arguments": "", "status": "in_progress"}
+            }),
+            serde_json::json!({
+                "type": "response.function_call_arguments.delta", "output_index": 0,
+                "item_id": "fc_1", "call_id": "call_1", "delta": r#"{"input":"hi \uD83D"#
+            }),
+            serde_json::json!({
+                "type": "response.function_call_arguments.delta", "output_index": 0,
+                "item_id": "fc_1", "call_id": "call_1", "delta": r#"\uDE00"}"#
+            }),
+        ];
+
+        let frames = events
+            .iter()
+            .flat_map(|event| translate(&mut accumulator, &mut translator, event).frames)
+            .collect::<Vec<_>>();
+        let input = frames
+            .iter()
+            .filter(|frame| frame.event_type == SSEEventType::CustomToolCallInputDelta)
+            .filter_map(|frame| frame.wire.rest["delta"].as_str())
+            .collect::<String>();
+
+        assert_eq!(input, "hi 😀");
+    }
+
+    #[test]
+    fn custom_input_over_limit_is_rejected() {
+        let mut accumulator = ResponseAccumulator::new("resp_1".to_owned(), None);
+        let mut translator = FunctionSseTranslator::new(HashMap::from([("raw_echo".to_owned(), ToolType::Custom)]));
+        let added = serde_json::json!({
+            "type": "response.output_item.added", "output_index": 0,
+            "item": {"id": "fc_1", "type": "function_call", "call_id": "call_1",
+                "name": "raw_echo", "arguments": "", "status": "in_progress"}
+        });
+        translate(&mut accumulator, &mut translator, &added);
+        let oversized = serde_json::json!({
+            "type": "response.function_call_arguments.delta", "output_index": 0,
+            "item_id": "fc_1", "call_id": "call_1",
+            "delta": format!("{{\"input\":\"{}", "x".repeat(MAX_PENDING_FUNCTION_BYTES + 1))
+        });
+
+        let error = accumulator
+            .process_sse_line_with_translator(&sse(&oversized), &mut translator)
+            .expect_err("oversized custom input must fail");
+        assert!(error.to_string().contains("function-call SSE exceeded"));
+    }
+
+    #[test]
     fn ordinary_functions_pass_through_unchanged() {
         let mut accumulator = ResponseAccumulator::new("resp_1".to_owned(), None);
         let mut translator = FunctionSseTranslator::new(HashMap::from([("echo".to_owned(), ToolType::Function)]));
@@ -659,6 +839,145 @@ mod tests {
         assert_eq!(frames[1].wire.rest["item_id"], "fc_transient");
         assert_eq!(frames[2].wire.rest["item"]["id"], "fc_stable");
         assert_eq!(defer_boundaries, [Some(1), Some(1), None]);
+    }
+
+    #[test]
+    fn parallel_unnamed_functions_with_empty_ids_remain_distinct() {
+        let mut accumulator = ResponseAccumulator::new("resp_1".to_owned(), None);
+        let mut translator = FunctionSseTranslator::new(HashMap::from([
+            ("first".to_owned(), ToolType::Function),
+            ("second".to_owned(), ToolType::Function),
+        ]));
+        let events = [
+            serde_json::json!({
+                "type": "response.output_item.added", "output_index": 0,
+                "item": {"id": "", "type": "function_call", "arguments": ""}
+            }),
+            serde_json::json!({
+                "type": "response.output_item.added", "output_index": 1,
+                "item": {"id": "", "type": "function_call", "arguments": ""}
+            }),
+            serde_json::json!({
+                "type": "response.function_call_arguments.delta", "output_index": 0,
+                "item_id": "", "delta": "{\"value\":\"a\"}"
+            }),
+            serde_json::json!({
+                "type": "response.function_call_arguments.delta", "output_index": 1,
+                "item_id": "", "delta": "{\"value\":\"b\"}"
+            }),
+            serde_json::json!({
+                "type": "response.output_item.done", "output_index": 0,
+                "item": {"id": "fc_first", "type": "function_call", "call_id": "call_first",
+                    "name": "first", "arguments": "{\"value\":\"a\"}", "status": "completed"}
+            }),
+            serde_json::json!({
+                "type": "response.output_item.done", "output_index": 1,
+                "item": {"id": "fc_second", "type": "function_call", "call_id": "call_second",
+                    "name": "second", "arguments": "{\"value\":\"b\"}", "status": "completed"}
+            }),
+        ];
+
+        let mut frames = Vec::new();
+        for event in events {
+            frames.extend(translate(&mut accumulator, &mut translator, &event).frames);
+        }
+
+        assert_eq!(
+            frames
+                .iter()
+                .filter(|frame| frame.event_type == SSEEventType::OutputItemAdded)
+                .count(),
+            2
+        );
+        assert_eq!(
+            frames
+                .iter()
+                .filter(|frame| frame.event_type == SSEEventType::OutputItemDone)
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn parallel_named_custom_functions_with_empty_ids_remain_distinct() {
+        let mut accumulator = ResponseAccumulator::new("resp_1".to_owned(), None);
+        let mut translator = FunctionSseTranslator::new(HashMap::from([
+            ("first".to_owned(), ToolType::Custom),
+            ("second".to_owned(), ToolType::Custom),
+        ]));
+        let events = [
+            serde_json::json!({
+                "type": "response.output_item.added", "output_index": 0,
+                "item": {"id": "", "type": "function_call", "call_id": "call_first",
+                    "name": "first", "arguments": "", "status": "in_progress"}
+            }),
+            serde_json::json!({
+                "type": "response.output_item.added", "output_index": 1,
+                "item": {"id": "", "type": "function_call", "call_id": "call_second",
+                    "name": "second", "arguments": "", "status": "in_progress"}
+            }),
+            serde_json::json!({
+                "type": "response.function_call_arguments.delta", "output_index": 0,
+                "item_id": "", "call_id": "call_first", "delta": "{\"input\":\"a\"}"
+            }),
+            serde_json::json!({
+                "type": "response.function_call_arguments.delta", "output_index": 1,
+                "item_id": "", "call_id": "call_second", "delta": "{\"input\":\"b\"}"
+            }),
+        ];
+
+        let frames = events
+            .iter()
+            .flat_map(|event| translate(&mut accumulator, &mut translator, event).frames)
+            .collect::<Vec<_>>();
+        let deltas = frames
+            .iter()
+            .filter(|frame| frame.event_type == SSEEventType::CustomToolCallInputDelta)
+            .map(|frame| (frame.wire.output_index, frame.wire.rest["delta"].as_str()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(deltas, [(Some(0), Some("a")), (Some(1), Some("b"))]);
+    }
+
+    #[test]
+    fn unnamed_custom_function_with_empty_id_uses_one_public_id() {
+        let mut accumulator = ResponseAccumulator::new("resp_1".to_owned(), None);
+        let mut translator = FunctionSseTranslator::new(HashMap::from([("raw_echo".to_owned(), ToolType::Custom)]));
+        let events = [
+            serde_json::json!({
+                "type": "response.output_item.added", "output_index": 0,
+                "item": {"id": "", "type": "function_call", "call_id": "call_1", "arguments": ""}
+            }),
+            serde_json::json!({
+                "type": "response.function_call_arguments.delta", "output_index": 0,
+                "item_id": "", "call_id": "call_1", "delta": "{\"input\":\"hello\"}"
+            }),
+            serde_json::json!({
+                "type": "response.function_call_arguments.done", "output_index": 0,
+                "item_id": "", "call_id": "call_1", "name": "raw_echo",
+                "arguments": "{\"input\":\"hello\"}"
+            }),
+        ];
+
+        let frames = events
+            .iter()
+            .flat_map(|event| translate(&mut accumulator, &mut translator, event).frames)
+            .collect::<Vec<_>>();
+        let added_id = frames
+            .iter()
+            .find(|frame| frame.event_type == SSEEventType::OutputItemAdded)
+            .and_then(|frame| frame.wire.rest["item"]["id"].as_str())
+            .expect("custom item id");
+        let lifecycle_ids = frames.iter().filter_map(|frame| {
+            matches!(
+                frame.event_type,
+                SSEEventType::CustomToolCallInputDelta | SSEEventType::CustomToolCallInputDone
+            )
+            .then(|| frame.wire.rest["item_id"].as_str())
+            .flatten()
+        });
+
+        assert!(lifecycle_ids.eq(std::iter::repeat_n(added_id, 2)));
     }
 
     #[test]

--- a/crates/agentic-server-core/src/executor/upstream.rs
+++ b/crates/agentic-server-core/src/executor/upstream.rs
@@ -14,6 +14,8 @@ use crate::tool::ToolRegistry;
 use crate::types::request_response::ResponsePayload;
 use crate::utils::common::serialize_to_string;
 
+const MAX_DEFERRED_STREAM_BYTES: usize = 256 * 1024;
+
 struct StreamEmitContext<'a> {
     request: &'a RequestContext,
     registry: &'a ToolRegistry,
@@ -75,6 +77,7 @@ pub(super) async fn fetch_stream_payload(
     let mut function_sse = FunctionSseTranslator::new(registry.tool_type_map());
     let mut defer_from_output_index = None;
     let mut deferred_events = Vec::new();
+    let mut deferred_bytes = 0;
     while let Some(line_result) = line_stream.next().await {
         let line = line_result?;
         if stream.is_none() {
@@ -104,11 +107,17 @@ pub(super) async fn fetch_stream_payload(
                             &mut emit_ctx,
                             defer_from_output_index,
                             &mut deferred_events,
+                            &mut deferred_bytes,
                         )?;
                     }
                 }
                 if defer_from_output_index != previous_defer_from_output_index {
-                    flush_released_stream_frames(&mut emit_ctx, defer_from_output_index, &mut deferred_events)?;
+                    flush_released_stream_frames(
+                        &mut emit_ctx,
+                        defer_from_output_index,
+                        &mut deferred_events,
+                        &mut deferred_bytes,
+                    )?;
                 }
             }
         }
@@ -198,9 +207,20 @@ fn emit_or_defer_stream_frame(
     emit_ctx: &mut StreamEmitContext<'_>,
     defer_from_output_index: Option<u64>,
     deferred_events: &mut Vec<EventFrame>,
+    deferred_bytes: &mut usize,
 ) -> ExecutorResult<()> {
     if should_defer_stream_event(&frame, defer_from_output_index) {
+        let frame_bytes = serialize_to_string(&frame.wire)
+            .map_err(ExecutorError::JsonError)?
+            .len();
+        let next_bytes = deferred_bytes.saturating_add(frame_bytes);
+        if next_bytes > MAX_DEFERRED_STREAM_BYTES {
+            return Err(ExecutorError::StreamError(format!(
+                "deferred stream exceeded {MAX_DEFERRED_STREAM_BYTES} buffered bytes"
+            )));
+        }
         deferred_events.push(frame);
+        *deferred_bytes = next_bytes;
         return Ok(());
     }
     emit_stream_frame(&mut frame, emit_ctx)
@@ -210,10 +230,19 @@ fn flush_released_stream_frames(
     emit_ctx: &mut StreamEmitContext<'_>,
     defer_from_output_index: Option<u64>,
     deferred_events: &mut Vec<EventFrame>,
+    deferred_bytes: &mut usize,
 ) -> ExecutorResult<()> {
-    let pending = std::mem::take(deferred_events);
+    let mut pending = std::mem::take(deferred_events);
+    *deferred_bytes = 0;
+    pending.sort_by_key(|frame| frame.wire.output_index);
     for frame in pending {
-        emit_or_defer_stream_frame(frame, emit_ctx, defer_from_output_index, deferred_events)?;
+        emit_or_defer_stream_frame(
+            frame,
+            emit_ctx,
+            defer_from_output_index,
+            deferred_events,
+            deferred_bytes,
+        )?;
     }
     Ok(())
 }
@@ -238,5 +267,110 @@ fn apply_context_response_ids(wire: &mut WireEvent, ctx: &RequestContext) {
     }
     if let Some(conversation_id) = &ctx.conversation_id {
         response.insert("conversation_id".to_owned(), Value::String(conversation_id.clone()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::EventPayload;
+    use crate::types::io::ResponsesInput;
+    use crate::types::request_response::RequestPayload;
+
+    fn request_context() -> RequestContext {
+        let request = RequestPayload {
+            model: "test".to_owned(),
+            input: ResponsesInput::Text("hi".to_owned()),
+            instructions: None,
+            previous_response_id: None,
+            conversation_id: None,
+            tools: None,
+            tool_choice: None,
+            stream: true,
+            store: false,
+            include: None,
+            temperature: None,
+            top_p: None,
+            max_output_tokens: None,
+            truncation: None,
+            metadata: None,
+            parallel_tool_calls: None,
+            cache_salt: None,
+            context_management: None,
+        };
+        RequestContext {
+            original_request: request.clone(),
+            enriched_request: request,
+            new_input_items: Vec::new(),
+            response_id: "resp_test".to_owned(),
+            conversation_id: None,
+            conversation_version: None,
+        }
+    }
+
+    fn frame(output_index: u64, payload: Value) -> EventFrame {
+        let mut wire = WireEvent::new("response.output_item.added");
+        wire.output_index = Some(output_index);
+        wire.rest.insert("item".to_owned(), payload);
+        EventFrame {
+            event_type: SSEEventType::OutputItemAdded,
+            payload: EventPayload::None,
+            wire,
+        }
+    }
+
+    #[test]
+    fn released_frames_are_emitted_in_output_index_order() {
+        let request = request_context();
+        let registry = ToolRegistry::default();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        let mut accumulator = GatewayStreamAccumulator::new();
+        let mut emit_ctx = StreamEmitContext {
+            request: &request,
+            registry: &registry,
+            sender: &sender,
+            accumulator: &mut accumulator,
+            output_offset: 0,
+        };
+        let mut deferred = vec![
+            frame(3, serde_json::json!({"id": "msg_3"})),
+            frame(2, serde_json::json!({"id": "msg_2"})),
+        ];
+        let mut deferred_bytes = deferred
+            .iter()
+            .map(|frame| serialize_to_string(&frame.wire).unwrap().len())
+            .sum();
+
+        flush_released_stream_frames(&mut emit_ctx, None, &mut deferred, &mut deferred_bytes).expect("flush succeeds");
+        assert_eq!(deferred_bytes, 0);
+
+        let indices = [receiver.try_recv().unwrap(), receiver.try_recv().unwrap()].map(|event| {
+            crate::events::normalize_sse_line(event.content.trim())
+                .and_then(|frame| frame.wire.output_index)
+                .expect("output index")
+        });
+        assert_eq!(indices, [2, 3]);
+    }
+
+    #[test]
+    fn deferred_frames_have_a_shared_byte_limit() {
+        let request = request_context();
+        let registry = ToolRegistry::default();
+        let (sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
+        let mut accumulator = GatewayStreamAccumulator::new();
+        let mut emit_ctx = StreamEmitContext {
+            request: &request,
+            registry: &registry,
+            sender: &sender,
+            accumulator: &mut accumulator,
+            output_offset: 0,
+        };
+        let mut deferred = Vec::new();
+        let mut deferred_bytes = 0;
+        let oversized = frame(0, Value::String("x".repeat(256 * 1024 + 1)));
+
+        let error = emit_or_defer_stream_frame(oversized, &mut emit_ctx, Some(0), &mut deferred, &mut deferred_bytes)
+            .expect_err("oversized deferred stream must fail");
+        assert!(error.to_string().contains("deferred stream exceeded"));
     }
 }

--- a/crates/agentic-server-core/src/tool/custom.rs
+++ b/crates/agentic-server-core/src/tool/custom.rs
@@ -229,7 +229,11 @@ impl ToolHandler for CustomHandler {
     fn validate(&self, param: &serde_json::Value) -> Result<(), ToolError> {
         let param = serde_json::from_value::<CustomToolParam>(param.clone())
             .map_err(|error| ToolError::Config(format!("invalid custom tool config: {error}")))?;
-        if param.format.is_some() {
+        if param
+            .format
+            .as_ref()
+            .is_some_and(|format| format.get("type").and_then(Value::as_str) != Some("text"))
+        {
             return Err(ToolError::Config(format!(
                 "custom tool '{}' uses an unsupported format; gateway normalization cannot preserve constrained decoding",
                 param.name
@@ -297,7 +301,7 @@ pub(crate) fn input_from_arguments(arguments: &str) -> String {
 pub(crate) fn try_input_from_arguments(arguments: &str) -> Option<String> {
     match serde_json::from_str::<serde_json::Value>(arguments).ok()? {
         serde_json::Value::String(input) => Some(input),
-        serde_json::Value::Object(fields) if fields.len() == 1 => fields
+        serde_json::Value::Object(fields) => fields
             .get("input")
             .and_then(serde_json::Value::as_str)
             .map(str::to_owned),
@@ -380,6 +384,18 @@ mod tests {
             let error = CustomHandler.validate(&value).expect_err("grammar must be rejected");
             assert!(error.to_string().contains("cannot preserve constrained decoding"));
         }
+    }
+
+    #[test]
+    fn explicit_text_format_is_supported() {
+        let param = serde_json::json!({
+            "name": "freeform",
+            "format": {"type": "text"}
+        });
+
+        CustomHandler
+            .validate(&param)
+            .expect("unconstrained text is representable");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #158 by @maralbahari, which added OpenAI-compatible custom tool SSE lifecycle translation.

## Summary

- Keep parallel unnamed function calls distinct by tracking unresolved calls with their output index.
- Preserve output-index ordering when deferred stream frames are released.
- Accept explicit unconstrained `{"type":"text"}` custom tool formats while continuing to reject grammar constraints that normalization cannot preserve.
- Keep streamed custom tool deltas consistent with the authoritative `input.done` value.
- Decode only newly arrived custom input and bound custom-call and deferred-stream buffering.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo clippy --offline --all-targets -- -D warnings`
- `cargo test --offline`
