### PR TITLE
test: parse named SSE frames in upstream test

### DIFF
--- a/crates/agentic-server-core/src/executor/upstream.rs
+++ b/crates/agentic-server-core/src/executor/upstream.rs
@@ -345,7 +345,12 @@ mod tests {
         assert_eq!(deferred_bytes, 0);
 
         let indices = [receiver.try_recv().unwrap(), receiver.try_recv().unwrap()].map(|event| {
-            crate::events::normalize_sse_line(event.content.trim())
+            let data_line = event
+                .content
+                .lines()
+                .find(|line| line.starts_with("data: "))
+                .expect("SSE data line");
+            crate::events::normalize_sse_line(data_line)
                 .and_then(|frame| frame.wire.output_index)
                 .expect("output index")
         });


### PR DESCRIPTION
## Summary

Update the upstream stream-ordering unit test to parse the `data:` line from a complete SSE frame.

PR #167 changed gateway streaming output to include named `event:` headers. The test still passed the whole frame to `normalize_sse_line`, which only accepts a `data:` line and caused the Rust workflow on `main` to fail.

## Test Plan

- `cargo test -p agentic-server-core executor::upstream::tests::released_frames_are_emitted_in_output_index_order -- --exact`
- `cargo test --workspace --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
