### PR TITLE
fix: preserve MCP discovery failures

### DIFF
--- a/crates/agentic-server-core/src/tool/mcp/handler.rs
+++ b/crates/agentic-server-core/src/tool/mcp/handler.rs
@@ -227,6 +227,13 @@ impl McpHandler {
         }
     }
 
+    #[must_use]
+    pub(crate) fn failed_list_tools_item(server_label: &str, error: &ToolError) -> McpListTools {
+        let mut item = McpListTools::new(uuid7_str("mcpl_"), server_label, Vec::new());
+        item.error = Some(error.to_string());
+        item
+    }
+
     /// Returns the spec-only MCP tool handler used during request normalization.
     #[must_use]
     pub const fn spec_from_param(_param: &Value) -> Self {

--- a/crates/agentic-server-core/src/tool/registry.rs
+++ b/crates/agentic-server-core/src/tool/registry.rs
@@ -210,7 +210,13 @@ impl ToolRegistry {
                     insert_unique_tool_entries(&mut entries, |resolved| insert_function_entry(resolved, p))?;
                 }
                 ResponsesTool::Mcp(p) => {
-                    let tool_set = executors.mcp_server_tools(p).await?;
+                    let tool_set = match executors.mcp_server_tools(p).await {
+                        Ok(tool_set) => tool_set,
+                        Err(error) => {
+                            mcp_list_tools_items.push(McpHandler::failed_list_tools_item(&p.server_label, &error));
+                            continue;
+                        }
+                    };
                     let handlers = tool_set.discovered_handlers;
                     mcp_list_tools_items.push(tool_set.list_tools_item);
                     if let ResponsesTool::Mcp(declaration) = &mut tools[index] {
@@ -557,6 +563,29 @@ mod tests {
             [crate::types::tools::CodexNamespaceMember::Function(function)] if function.name.as_str() == "run"
         ));
         assert_namespace_call_restoration(&registry);
+    }
+
+    #[tokio::test]
+    async fn build_with_handlers_retains_mcp_discovery_failure_output() {
+        let mut tools = vec![declaration("unreachable")];
+        let mut executors = GatewayExecutors::default();
+
+        let registry = ToolRegistry::build_with_handlers(&mut tools, &mut executors)
+            .await
+            .expect("discovery failures should become response metadata");
+
+        let [list_tools] = registry.mcp_list_tools_items() else {
+            panic!("expected one MCP list-tools item");
+        };
+        assert_eq!(list_tools.server_label, "unreachable");
+        assert!(list_tools.tools.is_empty());
+        assert!(
+            list_tools
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("failed"))
+        );
+        assert!(registry.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Preserve MCP discovery failures as error-bearing `mcp_list_tools` response items instead of aborting request-scoped registry construction.

When an MCP server cannot connect, `tools/list` fails, or the final allowed tool set is empty, the gateway now retains the failure metadata so streaming requests can emit the existing `response.mcp_list_tools.failed` lifecycle and non-streaming requests can include the failed output item.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo clippy -p agentic-server-core --all-targets -- -D warnings`
- `cargo test -p agentic-server-core --test mcp_tool_test`
- `cargo test -p agentic-server-core mcp --lib` (52 passed; 3 existing socket-permission tests are blocked by the sandbox)
