### PR TITLE
chore: prepare release v0.3.0

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -108,7 +108,6 @@ jobs:
           echo "Release version: $core_version"
           echo "version=$core_version" >> "$GITHUB_OUTPUT"
           echo "tag=v$core_version" >> "$GITHUB_OUTPUT"
-          echo "release_branch=releases/v$core_version" >> "$GITHUB_OUTPUT"
 
       - name: Resolve release commit
         id: target
@@ -123,18 +122,10 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ steps.version.outputs.tag }}"
-          release_branch="${{ steps.version.outputs.release_branch }}"
           target_sha="${{ steps.target.outputs.sha }}"
 
           if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
             echo "::error::Tag $tag already exists"
-            exit 1
-          fi
-
-          existing_branch_sha="$(git ls-remote --heads origin "refs/heads/$release_branch" | awk '{print $1}')"
-
-          if [ -n "$existing_branch_sha" ] && [ "$existing_branch_sha" != "$target_sha" ]; then
-            echo "::error::Release branch $release_branch already exists at $existing_branch_sha, not target $target_sha"
             exit 1
           fi
 
@@ -161,7 +152,6 @@ jobs:
           cargo package -p agentic-server --no-verify
           echo "Would release commit ${{ steps.target.outputs.sha }}"
           echo "Would create tag ${{ steps.version.outputs.tag }}"
-          echo "Would create branch ${{ steps.version.outputs.release_branch }}"
           echo "Would create GitHub release ${{ steps.version.outputs.tag }} with generated notes"
 
       - name: Publish agentic-server-core
@@ -200,7 +190,6 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ steps.version.outputs.tag }}"
-          release_branch="${{ steps.version.outputs.release_branch }}"
           target_sha="${{ steps.target.outputs.sha }}"
 
           git config user.name "github-actions[bot]"
@@ -208,7 +197,6 @@ jobs:
 
           git tag -a "$tag" "$target_sha" -m "$tag"
           git push origin "$tag"
-          git push origin "$target_sha:refs/heads/$release_branch"
 
       - name: Create GitHub release
         if: ${{ !inputs.dry_run }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,14 @@ version = 4
 
 [[package]]
 name = "agentic-praxis"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "agentic-server-core",
 ]
 
 [[package]]
 name = "agentic-server"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "agentic-server-core",
  "axum",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentic-server-core"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/vllm-project/agentic-api"
@@ -16,7 +16,7 @@ all = { level = "deny", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-agentic-core = { package = "agentic-server-core", path = "crates/agentic-server-core", version = "0.1.0" }
+agentic-core = { package = "agentic-server-core", path = "crates/agentic-server-core", version = "0.3.0" }
 async-stream = "0.3"
 axum = { version = "0.8", features = ["ws"] }
 either = "1"


### PR DESCRIPTION
## Summary

Prepare the workspace for the v0.3.0 release and make the release workflow compatible with repository branch-creation rules.

- Bump all workspace crates and the internal `agentic-core` dependency to `0.3.0`.
- Refresh `Cargo.lock`.
- Keep release commits, tags, and GitHub releases automated.
- Remove temporary release-branch creation and validation, which fails under the repository's branch-creation restrictions.

After this PR is merged, publish `agentic-server-core` first, wait for crates.io indexing, then publish `agentic-server`.

## Test Plan

- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (all executed tests passed; 8 PostgreSQL integration tests are ignored because `TEST_POSTGRES_URL` is not configured)
